### PR TITLE
feat(metrics): add circuit breaker OpenTelemetry metrics

### DIFF
--- a/documents/configuration/ojp-server-configuration.md
+++ b/documents/configuration/ojp-server-configuration.md
@@ -122,6 +122,7 @@ For detailed configuration examples for each database, see [SSL/TLS Certificate 
 |-------------------------------|-------------------------------|---------|---------|------------------------------------------------|-------|
 | `ojp.telemetry.enabled`   | `OJP_TELEMETRY_ENABLED`   | boolean | true    | Master switch: Enable/disable OpenTelemetry infrastructure (Prometheus server, MeterProvider, TracerProvider)  | 0.2.0-beta |
 | `ojp.opentelemetry.endpoint`  | `OJP_OPENTELEMETRY_ENDPOINT`  | string  | ""      | OpenTelemetry exporter endpoint (empty = default) | 0.2.0-beta |
+| `ojp.telemetry.circuitbreaker.enabled` | `OJP_TELEMETRY_CIRCUITBREAKER_ENABLED` | boolean | true | Enable/disable circuit breaker metrics while keeping other telemetry enabled | 0.4.0-beta |
 
 ### Tracing Settings
 
@@ -351,7 +352,7 @@ Set configuration using environment variables:
 ```bash
 export OJP_SERVER_PORT=8080
 export OJP_PROMETHEUS_PORT=9091
-export OJP_OPENTELEMETRY_ENABLED=false
+export OJP_TELEMETRY_ENABLED=false
 export OJP_SERVER_VIRTUALTHREADS_ENABLED=true
 export OJP_SERVER_THREADPOOLSIZE=100
 export OJP_SERVER_CIRCUITBREAKERTIMEOUT=120000
@@ -367,7 +368,7 @@ java -Duser.timezone=UTC -jar ojp-server.jar
 ```bash
 docker run -e OJP_SERVER_PORT=8080 \
            -e OJP_PROMETHEUS_PORT=9091 \
-           -e OJP_OPENTELEMETRY_ENABLED=false \
+           -e OJP_TELEMETRY_ENABLED=false \
            -e OJP_SERVER_CIRCUITBREAKERTIMEOUT=120000 \
            -e OJP_SERVER_SLOWQUERYSEGREGATION_ENABLED=true \
            -e OJP_SERVER_ALLOWEDIPS="192.168.1.0/24,10.0.0.1" \
@@ -585,7 +586,7 @@ data:
   OJP_SERVER_SLOWQUERYSEGREGATION_FASTSLOTTIMEOUT: "60000"
   OJP_SERVER_ALLOWEDIPS: "10.244.0.0/16"
   OJP_PROMETHEUS_ALLOWEDIPS: "10.244.0.0/16"
-  OJP_OPENTELEMETRY_ENABLED: "true"
+  OJP_TELEMETRY_ENABLED: "true"
 ```
 
 ## Configuration Validation

--- a/documents/ebook/part2-chapter6-server-configuration.md
+++ b/documents/ebook/part2-chapter6-server-configuration.md
@@ -192,7 +192,7 @@ Modern observability goes beyond logs. OJP integrates with OpenTelemetry to prov
 **Note**: OJP exports metrics via Prometheus and also supports distributed tracing via OpenTelemetry. Metrics are enabled by default; distributed tracing must be explicitly enabled via configuration (see Chapter 13 for full tracing configuration details). The OpenTelemetry integration provides operational metrics such as request rates, error rates, and latency through the Prometheus endpoint, as well as distributed traces to Zipkin or OTLP-compatible backends such as Jaeger and Grafana Tempo.
 
 
-OpenTelemetry support is enabled by default, making the Prometheus metrics endpoint available at the configured port (default 9159). The server provides separate control over different metric categories, allowing you to enable or disable gRPC and pool metrics independently.
+OpenTelemetry support is enabled by default, making the Prometheus metrics endpoint available at the configured port (default 9159). The server provides separate control over different metric categories, allowing you to enable or disable gRPC, pool, and circuit breaker metrics independently.
 
 **[IMAGE PROMPT: Create a metrics dashboard visualization showing Prometheus metrics from OJP Server. Display panels for: "Request Rate" (line graph), "Connection Pool Usage" (gauge showing active/idle/max), "Pool Utilization %" (multi-pool comparison), "Query Latency p95/p99" (histogram), "Error Rate" (area chart), "Pool Health" (stat panel showing exhaustion/leaks). Use modern Grafana-style UI with dark theme, multiple time series, and clear metric labels. Style: Modern observability dashboard with color-coded metrics and real-time graphs.]**
 
@@ -205,12 +205,13 @@ The configuration provides three levels of control:
 # Granular control over metric categories (both default to true when telemetry is enabled)
 -Dojp.telemetry.grpc.metrics.enabled=true      # gRPC server metrics
 -Dojp.telemetry.pool.metrics.enabled=true      # Connection pool metrics (XA, HikariCP, DBCP)
+-Dojp.telemetry.circuitbreaker.enabled=true    # Circuit breaker metrics
 
 # Disable telemetry completely for performance-critical scenarios
 -Dojp.telemetry.enabled=false
 ```
 
-This three-tier approach lets you optimize your observability setup. The master switch (`ojp.telemetry.enabled`) controls whether the OpenTelemetry SDK and Prometheus server initialize at all. When disabled, the system uses no-op telemetry with zero overhead. The granular flags (`ojp.telemetry.grpc.metrics.enabled`, `ojp.telemetry.pool.metrics.enabled`) control which metrics are collected within an already-initialized OpenTelemetry system, allowing you to focus on the metrics that matter most for your deployment.
+This three-tier approach lets you optimize your observability setup. The master switch (`ojp.telemetry.enabled`) controls whether the OpenTelemetry SDK and Prometheus server initialize at all. When disabled, the system uses no-op telemetry with zero overhead. The granular flags (`ojp.telemetry.grpc.metrics.enabled`, `ojp.telemetry.pool.metrics.enabled`, `ojp.telemetry.circuitbreaker.enabled`) control which metrics are collected within an already-initialized OpenTelemetry system, allowing you to focus on the metrics that matter most for your deployment.
 
 ### Available Metrics
 
@@ -420,7 +421,7 @@ export OJP_SERVER_VIRTUALTHREADS_ENABLED=true
 export OJP_SERVER_THREADPOOLSIZE=50
 export OJP_SERVER_CIRCUITBREAKERTHRESHOLD=5
 export OJP_SERVER_ALLOWEDIPS="0.0.0.0/0"
-export OJP_OPENTELEMETRY_ENABLED=true
+export OJP_TELEMETRY_ENABLED=true
 ```
 
 Production environments require different trade-offs. Use ERROR or INFO logging (ERROR recommended for maximum performance; INFO for operational visibility). Implement proper IP restrictions for security. Enable OpenTelemetry for distributed tracing. Configure appropriate timeouts for your SLAs. Be very careful with DEBUG and TRACE in production—they are extremely verbose and can impact performance significantly.
@@ -436,7 +437,7 @@ export OJP_SERVER_CIRCUITBREAKERTHRESHOLD=3
 export OJP_SERVER_CIRCUITBREAKERTIMEOUT=60000
 export OJP_SERVER_ALLOWEDIPS="10.0.0.0/8"
 export OJP_PROMETHEUS_ALLOWEDIPS="192.168.100.0/24"
-export OJP_OPENTELEMETRY_ENABLED=true
+export OJP_TELEMETRY_ENABLED=true
 export OJP_OPENTELEMETRY_ENDPOINT=http://jaeger:4317
 export OJP_SERVER_SLOWQUERYSEGREGATION_ENABLED=true
 ```

--- a/documents/telemetry/README.md
+++ b/documents/telemetry/README.md
@@ -11,6 +11,7 @@ OJP exposes operational metrics through a Prometheus-compatible endpoint, provid
 - Connection pool metrics (XA pools and HikariCP) including connection acquisition time histograms
 - SQL execution time histograms per statement (for both XA and non-XA connections)
 - Connection and session information
+- Circuit breaker state, trips, blocked calls, and recovery timing
 
 ### Distributed Tracing via OpenTelemetry
 OJP supports distributed tracing using the OpenTelemetry SDK. Traces are automatically emitted for all gRPC calls handled by the server and can be sent to any compatible backend.
@@ -40,6 +41,80 @@ Traces are pushed by OJP to the configured exporter endpoint:
 - **OTLP default endpoint**: `http://localhost:4317` (gRPC)
 
 Each trace includes span attributes such as gRPC method, status code, and service name.
+
+## Circuit Breaker Metrics
+
+When `ojp.telemetry.enabled=true`, OJP emits circuit breaker metrics through the same Prometheus endpoint. These metrics are labeled with `query_hash` and `datasource`; transition and trip metrics include additional labels noted below.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ojp.circuit_breaker.state` | Gauge | `query_hash`, `datasource` | Current circuit state: `0` closed, `1` open, `2` half-open |
+| `ojp.circuit_breaker.transitions.total` | Counter | `query_hash`, `datasource`, `from_state`, `to_state` | Number of state transitions |
+| `ojp.circuit_breaker.trips.total` | Counter | `query_hash`, `datasource`, `reason` | Number of times a circuit opens due to failure conditions |
+| `ojp.circuit_breaker.open_duration.seconds` | Histogram | `query_hash`, `datasource` | Time spent in open state before recovery is attempted |
+| `ojp.circuit_breaker.blocked_calls.total` | Counter | `query_hash`, `datasource` | Requests rejected because the circuit is open |
+
+Prometheus converts OpenTelemetry metric names to Prometheus format by replacing dots with underscores. For example, `ojp.circuit_breaker.trips.total` is queried as `ojp_circuit_breaker_trips_total`.
+
+### Example Prometheus Queries
+
+Circuits currently open:
+```promql
+ojp_circuit_breaker_state == 1
+```
+
+Circuit trips by datasource over five minutes:
+```promql
+sum by (datasource) (increase(ojp_circuit_breaker_trips_total[5m]))
+```
+
+Blocked calls by query over five minutes:
+```promql
+sum by (datasource, query_hash) (increase(ojp_circuit_breaker_blocked_calls_total[5m]))
+```
+
+95th percentile open duration:
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, datasource) (rate(ojp_circuit_breaker_open_duration_seconds_bucket[5m]))
+)
+```
+
+State transitions by direction:
+```promql
+sum by (from_state, to_state) (increase(ojp_circuit_breaker_transitions_total[5m]))
+```
+
+### Grafana Panel Snippets
+
+Current open circuits:
+```json
+{
+  "title": "Open circuits",
+  "type": "stat",
+  "targets": [
+    {
+      "expr": "count(ojp_circuit_breaker_state == 1)",
+      "legendFormat": "open"
+    }
+  ]
+}
+```
+
+Circuit trips by datasource:
+```json
+{
+  "title": "Circuit trips by datasource",
+  "type": "timeseries",
+  "targets": [
+    {
+      "expr": "sum by (datasource) (increase(ojp_circuit_breaker_trips_total[5m]))",
+      "legendFormat": "{{datasource}}"
+    }
+  ]
+}
+```
 
 ## Configuration Options
 

--- a/documents/telemetry/README.md
+++ b/documents/telemetry/README.md
@@ -127,6 +127,7 @@ The telemetry system can be configured through JVM system properties or environm
 | `ojp.telemetry.enabled` | `OJP_TELEMETRY_ENABLED` | `true` | Master switch: Enable/disable OpenTelemetry infrastructure (Prometheus server, MeterProvider, TracerProvider) |
 | `ojp.prometheus.port` | `OJP_PROMETHEUS_PORT` | `9159` | Port for Prometheus metrics HTTP server |
 | `ojp.prometheus.allowedIps` | `OJP_PROMETHEUS_ALLOWED_IPS` | `0.0.0.0/0` | Comma-separated list of allowed IP addresses/CIDR blocks for metrics endpoint |
+| `ojp.telemetry.circuitbreaker.enabled` | `OJP_TELEMETRY_CIRCUITBREAKER_ENABLED` | `true` | Enable/disable circuit breaker metrics while keeping other telemetry enabled |
 
 ### Tracing Configuration Properties
 
@@ -161,9 +162,10 @@ java -Duser.timezone=UTC \
 
 **Using Environment Variables:**
 ```bash
-export OJP_OPENTELEMETRY_ENABLED=true
+export OJP_TELEMETRY_ENABLED=true
 export OJP_PROMETHEUS_PORT=9159
 export OJP_PROMETHEUS_ALLOWED_IPS=127.0.0.1,10.0.0.0/8
+export OJP_TELEMETRY_CIRCUITBREAKER_ENABLED=false
 export OJP_TRACING_ENABLED=true
 export OJP_TRACING_ENDPOINT=http://zipkin:9411/api/v2/spans
 java -Duser.timezone=UTC -jar ojp-server.jar

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreaker.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreaker.java
@@ -116,6 +116,7 @@ public class CircuitBreaker {
             rec.reset();
             state.remove(sql, rec);
             metrics.updateState(resourceId, sql, CircuitBreakerMetrics.State.CLOSED);
+            metrics.clearState(resourceId, sql);
         }
     }
 

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreaker.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreaker.java
@@ -1,9 +1,11 @@
 package org.openjproxy.grpc.server;
 
 import java.sql.SQLException;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 import lombok.extern.slf4j.Slf4j;
 /**
@@ -16,26 +18,28 @@ public class CircuitBreaker {
         private final AtomicInteger failureCount = new AtomicInteger(0);
         private final AtomicLong openUntil = new AtomicLong(0);
         private final int failureThreshold;
+        private final LongSupplier nanoTimeSupplier;
 
-        public FailureRecord(int failureThreshold) {
+        public FailureRecord(int failureThreshold, LongSupplier nanoTimeSupplier) {
             this.failureThreshold = failureThreshold;
+            this.nanoTimeSupplier = nanoTimeSupplier;
         }
 
         public void recordFailure(SQLException error, long openMs) {
             lastError = error;
             int failures = failureCount.incrementAndGet();
             if (failures >= failureThreshold) {
-                openUntil.updateAndGet(prev -> Math.max(prev, System.nanoTime() + openMs * 1_000_000L));
+                openUntil.updateAndGet(prev -> Math.max(prev, nanoTimeSupplier.getAsLong() + openMs * 1_000_000L));
             }
         }
 
         public boolean isOpen() {
             return failureCount.get() >= failureThreshold
-                && System.nanoTime() <= openUntil.get();
+                && nanoTimeSupplier.getAsLong() <= openUntil.get();
         }
 
         public boolean tryReset() {
-            return System.nanoTime() > openUntil.get()
+            return nanoTimeSupplier.getAsLong() > openUntil.get()
                 && failureCount.get() >= failureThreshold;
         }
 
@@ -58,10 +62,29 @@ public class CircuitBreaker {
     private final long openMs;
     private final int failureThreshold;
     private final String resourceId;
+    private final CircuitBreakerMetrics metrics;
+    private final LongSupplier nanoTimeSupplier;
+
     public CircuitBreaker(long openMs, int failureThreshold, String resourceId) {
+        this(openMs, failureThreshold, resourceId, CircuitBreakerMetrics.noop());
+    }
+
+    public CircuitBreaker(long openMs, int failureThreshold, String resourceId, CircuitBreakerMetrics metrics) {
+        this(openMs, failureThreshold, resourceId, metrics, System::nanoTime);
+    }
+
+    CircuitBreaker(
+            long openMs,
+            int failureThreshold,
+            String resourceId,
+            CircuitBreakerMetrics metrics,
+            LongSupplier nanoTimeSupplier
+    ) {
         this.openMs = openMs;
         this.failureThreshold = failureThreshold;
         this.resourceId = resourceId;
+        this.metrics = Objects.requireNonNull(metrics, "metrics");
+        this.nanoTimeSupplier = Objects.requireNonNull(nanoTimeSupplier, "nanoTimeSupplier");
     }
 
     /**
@@ -75,9 +98,12 @@ public class CircuitBreaker {
             return;
         }
         if (rec.isOpen()) {
+            metrics.recordBlockedCall(resourceId, sql);
             throw rec.getLastError();
         }
-        rec.tryReset();
+        if (rec.tryReset()) {
+            metrics.updateState(resourceId, sql, CircuitBreakerMetrics.State.HALF_OPEN);
+        }
     }
 
     /**
@@ -89,6 +115,7 @@ public class CircuitBreaker {
         if (rec != null) {
             rec.reset();
             state.remove(sql, rec);
+            metrics.updateState(resourceId, sql, CircuitBreakerMetrics.State.CLOSED);
         }
     }
 
@@ -100,11 +127,22 @@ public class CircuitBreaker {
      * @param error The exception.
      */
     public void onFailure(String sql, SQLException error) {
-        FailureRecord rec = state.computeIfAbsent(sql, s -> new FailureRecord(this.failureThreshold));
+        FailureRecord rec = state.computeIfAbsent(
+                sql,
+                s -> new FailureRecord(this.failureThreshold, nanoTimeSupplier)
+        );
         if (!rec.isOpen()) {
             rec.recordFailure(error, openMs);
             if (rec.isOpen()) {
+                metrics.updateState(
+                        resourceId,
+                        sql,
+                        CircuitBreakerMetrics.State.OPEN,
+                        CircuitBreakerMetrics.TripReason.FAILURE_THRESHOLD
+                );
                 log.warn("Circuit Breaker TRIP: Resource Id [{}] is now OPEN for query key: {}", this.resourceId, sql);
+            } else {
+                metrics.updateState(resourceId, sql, CircuitBreakerMetrics.State.CLOSED);
             }
         }
     }

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreakerMetrics.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreakerMetrics.java
@@ -1,0 +1,243 @@
+package org.openjproxy.grpc.server;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CircuitBreakerMetrics {
+
+    private static final CircuitBreakerMetrics NOOP = new CircuitBreakerMetrics(OpenTelemetry.noop(), false);
+
+    private static final AttributeKey<String> QUERY_HASH = AttributeKey.stringKey("query_hash");
+    private static final AttributeKey<String> DATA_SOURCE = AttributeKey.stringKey("datasource");
+    private static final AttributeKey<String> FROM_STATE = AttributeKey.stringKey("from_state");
+    private static final AttributeKey<String> TO_STATE = AttributeKey.stringKey("to_state");
+    private static final AttributeKey<String> REASON = AttributeKey.stringKey("reason");
+
+    private final boolean enabled;
+    private final ObservableLongGauge stateGauge;
+    private final LongCounter transitionsCounter;
+    private final LongCounter tripsCounter;
+    private final LongCounter blockedCallsCounter;
+    private final DoubleHistogram openDurationHistogram;
+    private final ConcurrentHashMap<CircuitBreakerKey, State> states = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<CircuitBreakerKey, Long> openTimestamps = new ConcurrentHashMap<>();
+
+    public CircuitBreakerMetrics(OpenTelemetry openTelemetry) {
+        this(openTelemetry, true);
+    }
+
+    private CircuitBreakerMetrics(OpenTelemetry openTelemetry, boolean enabled) {
+        this.enabled = enabled;
+        Meter meter = Objects.requireNonNull(openTelemetry, "openTelemetry")
+                .getMeter("ojp.server.circuit.breaker");
+
+        this.stateGauge = meter
+                .gaugeBuilder("ojp.circuit_breaker.state")
+                .setDescription("Current circuit breaker state (0=CLOSED, 1=OPEN, 2=HALF_OPEN)")
+                .ofLongs()
+                .buildWithCallback(this::observeState);
+
+        this.transitionsCounter = meter.counterBuilder("ojp.circuit_breaker.transitions.total")
+                .setDescription("Counts circuit breaker state transitions")
+                .build();
+
+        this.tripsCounter = meter.counterBuilder("ojp.circuit_breaker.trips.total")
+                .setDescription("Counts when a circuit opens due to failure conditions")
+                .build();
+
+        this.blockedCallsCounter = meter.counterBuilder("ojp.circuit_breaker.blocked_calls.total")
+                .setDescription("Counts requests blocked because a circuit is open")
+                .build();
+
+        this.openDurationHistogram = meter
+                .histogramBuilder("ojp.circuit_breaker.open_duration.seconds")
+                .setDescription("Time circuit remains OPEN before recovery attempt")
+                .setUnit("s")
+                .build();
+    }
+
+    public static CircuitBreakerMetrics noop() {
+        return NOOP;
+    }
+
+    public void updateState(String datasource, String queryHash, State newState) {
+        updateState(datasource, queryHash, newState, null);
+    }
+
+    public void updateState(String datasource, String queryHash, State newState, TripReason tripReason) {
+        if (!enabled) {
+            return;
+        }
+
+        Objects.requireNonNull(newState, "newState");
+        CircuitBreakerKey key = CircuitBreakerKey.of(datasource, queryHash);
+
+        states.compute(key, (k, previousState) -> {
+            if (previousState == newState) {
+                return previousState;
+            }
+
+            State fromState = previousState == null ? State.CLOSED : previousState;
+            if (previousState == null && newState == State.CLOSED) {
+                return newState;
+            }
+
+            handleTransition(key, datasource, queryHash, fromState, newState, tripReason);
+            return newState;
+        });
+    }
+
+    public void recordBlockedCall(String datasource, String queryHash) {
+        if (!enabled) {
+            return;
+        }
+
+        blockedCallsCounter.add(
+                1,
+                Attributes.of(
+                        DATA_SOURCE, datasource,
+                        QUERY_HASH, queryHash
+                )
+        );
+    }
+
+    private void observeState(ObservableLongMeasurement observer) {
+        if (!enabled) {
+            return;
+        }
+
+        for (Map.Entry<CircuitBreakerKey, State> entry : states.entrySet()) {
+            CircuitBreakerKey key = entry.getKey();
+            observer.record(
+                    entry.getValue().value,
+                    Attributes.of(
+                            DATA_SOURCE, key.datasource,
+                            QUERY_HASH, key.queryHash
+                    )
+            );
+        }
+    }
+
+    private void handleTransition(
+            CircuitBreakerKey key,
+            String datasource,
+            String queryHash,
+            State previousState,
+            State newState,
+            TripReason tripReason
+    ) {
+        boolean enteringOpen = newState == State.OPEN;
+        boolean leavingOpen = previousState == State.OPEN && newState != State.OPEN;
+
+        transitionsCounter.add(
+                1,
+                Attributes.of(
+                        DATA_SOURCE, datasource,
+                        QUERY_HASH, queryHash,
+                        FROM_STATE, previousState.name(),
+                        TO_STATE, newState.name()
+                )
+        );
+
+        if (enteringOpen) {
+            validateTripReason(tripReason);
+            openTimestamps.put(key, System.nanoTime());
+            tripsCounter.add(
+                    1,
+                    Attributes.of(
+                            DATA_SOURCE, datasource,
+                            QUERY_HASH, queryHash,
+                            REASON, tripReason.name()
+                    )
+            );
+        }
+
+        if (leavingOpen) {
+            recordOpenDuration(key, datasource, queryHash);
+        }
+    }
+
+    private void recordOpenDuration(
+            CircuitBreakerKey key,
+            String datasource,
+            String queryHash
+    ) {
+        Long start = openTimestamps.remove(key);
+        if (start == null) {
+            return;
+        }
+
+        double durationSeconds = (System.nanoTime() - start) / 1_000_000_000.0;
+        openDurationHistogram.record(
+                durationSeconds,
+                Attributes.of(
+                        DATA_SOURCE, datasource,
+                        QUERY_HASH, queryHash
+                )
+        );
+    }
+
+    private void validateTripReason(TripReason tripReason) {
+        if (tripReason == null) {
+            throw new IllegalArgumentException(
+                    "TripReason must be provided when transitioning to OPEN"
+            );
+        }
+    }
+
+    private static final class CircuitBreakerKey {
+        private final String datasource;
+        private final String queryHash;
+
+        private CircuitBreakerKey(String datasource, String queryHash) {
+            this.datasource = Objects.requireNonNull(datasource, "datasource");
+            this.queryHash = Objects.requireNonNull(queryHash, "queryHash");
+        }
+
+        static CircuitBreakerKey of(String datasource, String queryHash) {
+            return new CircuitBreakerKey(datasource, queryHash);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CircuitBreakerKey that)) {
+                return false;
+            }
+            return datasource.equals(that.datasource) && queryHash.equals(that.queryHash);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(datasource, queryHash);
+        }
+    }
+
+    public enum TripReason {
+        FAILURE_THRESHOLD
+    }
+
+    enum State {
+        CLOSED(0),
+        OPEN(1),
+        HALF_OPEN(2);
+
+        final long value;
+
+        State(long value) {
+            this.value = value;
+        }
+    }
+}

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreakerMetrics.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreakerMetrics.java
@@ -70,6 +70,13 @@ public class CircuitBreakerMetrics {
         return NOOP;
     }
 
+    public void clearState(String datasource, String queryHash) {
+        CircuitBreakerKey key = CircuitBreakerKey.of(datasource, queryHash);
+
+        this.states.remove(key);
+        this.openTimestamps.remove(key);
+    }
+
     public void updateState(String datasource, String queryHash, State newState) {
         updateState(datasource, queryHash, newState, null);
     }

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreakerRegistry.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreakerRegistry.java
@@ -1,20 +1,27 @@
 package org.openjproxy.grpc.server;
 
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class CircuitBreakerRegistry {
 
-    private ConcurrentHashMap<String, CircuitBreaker> circuitBreakerStore = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CircuitBreaker> circuitBreakerStore = new ConcurrentHashMap<>();
     private final long openMs;
     private final int failureThreshold;
+    private final CircuitBreakerMetrics metrics;
 
     public CircuitBreakerRegistry(long openMs, int failureThreshold) {
+        this(openMs, failureThreshold, CircuitBreakerMetrics.noop());
+    }
+
+    public CircuitBreakerRegistry(long openMs, int failureThreshold, CircuitBreakerMetrics metrics) {
         this.openMs = openMs;
         this.failureThreshold = failureThreshold;
+        this.metrics = Objects.requireNonNull(metrics, "metrics");
     }
 
 
     public CircuitBreaker get(String key) {
-        return circuitBreakerStore.computeIfAbsent(key, k -> new CircuitBreaker(openMs, failureThreshold, key));
+        return circuitBreakerStore.computeIfAbsent(key, k -> new CircuitBreaker(openMs, failureThreshold, key, metrics));
     }
 }

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/GrpcServer.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/GrpcServer.java
@@ -27,7 +27,6 @@ public class GrpcServer {
         // Load configuration
         ServerConfiguration config = new ServerConfiguration();
 
-        CircuitBreakerRegistry circuitBreakerRegistry = new CircuitBreakerRegistry(config.getCircuitBreakerTimeout(), config.getCircuitBreakerThreshold());
         // Load external JDBC drivers from configured directory
         logger.info("Loading external JDBC drivers...");
         boolean driversLoaded = DriverLoader.loadDriversFromPath(config.getDriversPath());
@@ -48,6 +47,7 @@ public class GrpcServer {
         // Initialize telemetry based on configuration
         OjpServerTelemetry ojpServerTelemetry = new OjpServerTelemetry();
         GrpcTelemetry grpcTelemetry;
+        CircuitBreakerMetrics circuitBreakerMetrics;
 
         if (config.isOpenTelemetryEnabled()) {
             grpcTelemetry = ojpServerTelemetry.createGrpcTelemetry(
@@ -61,6 +61,7 @@ public class GrpcServer {
                 config.isTelemetryGrpcMetricsEnabled(),
                 config.isTelemetryPoolMetricsEnabled()
             );
+            circuitBreakerMetrics = ojpServerTelemetry.createCircuitBreakerMetrics();
 
             OjpHealthManager.setServiceStatus(OjpHealthManager.Services.OPENTELEMETRY_SERVICE,
                     HealthCheckResponse.ServingStatus.SERVING);
@@ -75,7 +76,14 @@ public class GrpcServer {
             }
         } else {
             grpcTelemetry = ojpServerTelemetry.createNoOpGrpcTelemetry();
+            circuitBreakerMetrics = CircuitBreakerMetrics.noop();
         }
+
+        CircuitBreakerRegistry circuitBreakerRegistry = new CircuitBreakerRegistry(
+                config.getCircuitBreakerTimeout(),
+                config.getCircuitBreakerThreshold(),
+                circuitBreakerMetrics
+        );
 
         // Build server with configuration
         // Create shared cache configuration map for session-level caching

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/GrpcServer.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/GrpcServer.java
@@ -61,7 +61,12 @@ public class GrpcServer {
                 config.isTelemetryGrpcMetricsEnabled(),
                 config.isTelemetryPoolMetricsEnabled()
             );
-            circuitBreakerMetrics = ojpServerTelemetry.createCircuitBreakerMetrics();
+            if (config.isTelemetryCircuitBreakerMetricsEnabled()) {
+                circuitBreakerMetrics = ojpServerTelemetry.createCircuitBreakerMetrics();
+            } else {
+                circuitBreakerMetrics = CircuitBreakerMetrics.noop();
+                logger.info("Circuit breaker metrics disabled");
+            }
 
             OjpHealthManager.setServiceStatus(OjpHealthManager.Services.OPENTELEMETRY_SERVICE,
                     HealthCheckResponse.ServingStatus.SERVING);

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/OjpServerTelemetry.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/OjpServerTelemetry.java
@@ -28,8 +28,8 @@ public class OjpServerTelemetry {
 	private static final Logger logger = LoggerFactory.getLogger(OjpServerTelemetry.class);
 	private static final int DEFAULT_PROMETHEUS_PORT = 9159;
 
-	// Store the OpenTelemetry instance for cache metrics initialization
-	private OpenTelemetry openTelemetry;
+	// Store the OpenTelemetry instance for cache and circuit breaker metrics initialization.
+	private OpenTelemetry openTelemetry = OpenTelemetry.noop();
 
 	/**
 	 * Get the OpenTelemetry instance (for cache metrics initialization).
@@ -86,19 +86,16 @@ public class OjpServerTelemetry {
 				.setPort(prometheusPort)
 				.build();
 
-		OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+		this.openTelemetry = OpenTelemetrySdk.builder()
 				.setMeterProvider(
 						SdkMeterProvider.builder()
 								.registerMetricReader(prometheusServer)
 								.build())
 				.build();
 
-		// Store the OpenTelemetry instance for cache metrics
-		this.openTelemetry = openTelemetry;
-
 		// Register OpenTelemetry instance for pool metrics if enabled
 		if (poolMetricsEnabled) {
-			org.openjproxy.xa.pool.commons.metrics.OpenTelemetryHolder.setInstance(openTelemetry);
+			org.openjproxy.xa.pool.commons.metrics.OpenTelemetryHolder.setInstance(this.openTelemetry);
 			logger.info("OpenTelemetry instance registered for pool metrics");
 		}
 
@@ -108,7 +105,7 @@ public class OjpServerTelemetry {
 		// for pool metrics and tracing if enabled.
 		if (grpcMetricsEnabled) {
 			logger.info("gRPC metrics enabled, creating instrumented GrpcTelemetry");
-			return GrpcTelemetry.create(openTelemetry);
+			return GrpcTelemetry.create(this.openTelemetry);
 		} else {
 			logger.info("gRPC metrics disabled, creating no-op GrpcTelemetry");
 			return GrpcTelemetry.create(OpenTelemetry.noop());
@@ -155,14 +152,11 @@ public class OjpServerTelemetry {
 			sdkBuilder.setTracerProvider(tracerProvider);
 		}
 
-		OpenTelemetry openTelemetry = sdkBuilder.build();
-
-		// Store the OpenTelemetry instance for cache metrics
-		this.openTelemetry = openTelemetry;
+		this.openTelemetry = sdkBuilder.build();
 
 		// Register OpenTelemetry instance for pool metrics if enabled
 		if (poolMetricsEnabled) {
-			org.openjproxy.xa.pool.commons.metrics.OpenTelemetryHolder.setInstance(openTelemetry);
+			org.openjproxy.xa.pool.commons.metrics.OpenTelemetryHolder.setInstance(this.openTelemetry);
 			logger.info("OpenTelemetry instance registered for pool metrics");
 		}
 
@@ -172,7 +166,7 @@ public class OjpServerTelemetry {
 		// for pool metrics and tracing if enabled.
 		if (grpcMetricsEnabled) {
 			logger.info("gRPC metrics enabled, creating instrumented GrpcTelemetry");
-			return GrpcTelemetry.create(openTelemetry);
+			return GrpcTelemetry.create(this.openTelemetry);
 		} else {
 			logger.info("gRPC metrics disabled, creating no-op GrpcTelemetry");
 			return GrpcTelemetry.create(OpenTelemetry.noop());
@@ -218,10 +212,18 @@ public class OjpServerTelemetry {
 	}
 
 	/**
+	 * Creates circuit breaker metrics using the same OpenTelemetry instance as the server metrics endpoint.
+	 */
+	public CircuitBreakerMetrics createCircuitBreakerMetrics() {
+		return new CircuitBreakerMetrics(openTelemetry);
+	}
+
+	/**
 	 * Creates a no-op GrpcTelemetry when OpenTelemetry is disabled.
 	 */
 	public GrpcTelemetry createNoOpGrpcTelemetry() {
 		logger.info("OpenTelemetry disabled, using no-op implementation");
-		return GrpcTelemetry.create(OpenTelemetry.noop());
+		openTelemetry = OpenTelemetry.noop();
+		return GrpcTelemetry.create(openTelemetry);
 	}
 }

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/ServerConfiguration.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/ServerConfiguration.java
@@ -611,8 +611,10 @@ public class ServerConfiguration {
         logger.info("TLS Configuration:");
         logger.info("  TLS Enabled: {}", tlsEnabled);
         if (tlsEnabled) {
-            logger.info("  TLS Keystore Path: {}", maskPath(tlsKeystorePath));
-            logger.info("  TLS Truststore Path: {}", maskPath(tlsTruststorePath));
+            if (logger.isInfoEnabled()) {
+                logger.info("  TLS Keystore Path: {}", maskPath(tlsKeystorePath));
+                logger.info("  TLS Truststore Path: {}", maskPath(tlsTruststorePath));
+            }
             logger.info("  TLS Client Auth Required (mTLS): {}", tlsClientAuthRequired);
             logger.info("  TLS Keystore Type: {}", tlsKeystoreType);
             logger.info("  TLS Truststore Type: {}", tlsTruststoreType);

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/ServerConfiguration.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/ServerConfiguration.java
@@ -91,6 +91,7 @@ public class ServerConfiguration {
     private static final String TELEMETRY_GRPC_METRICS_ENABLED_KEY = "ojp.telemetry.grpc.metrics.enabled";
     private static final String TELEMETRY_POOL_METRICS_ENABLED_KEY = "ojp.telemetry.pool.metrics.enabled";
     private static final String TELEMETRY_CACHE_METRICS_ENABLED_KEY = "ojp.telemetry.cache.metrics.enabled";
+    private static final String TELEMETRY_CIRCUIT_BREAKER_ENABLED_KEY = "ojp.telemetry.circuitbreaker.enabled";
 
     // TLS configuration keys
     private static final String TLS_ENABLED_KEY = "ojp.server.tls.enabled";
@@ -176,6 +177,7 @@ public class ServerConfiguration {
     public static final boolean DEFAULT_TELEMETRY_GRPC_METRICS_ENABLED = true; // Enabled by default when OpenTelemetry is enabled
     public static final boolean DEFAULT_TELEMETRY_POOL_METRICS_ENABLED = true; // Enabled by default when OpenTelemetry is enabled
     public static final boolean DEFAULT_TELEMETRY_CACHE_METRICS_ENABLED = true; // Enabled by default when OpenTelemetry is enabled
+    public static final boolean DEFAULT_TELEMETRY_CIRCUIT_BREAKER_ENABLED = true; // Enabled by default when OpenTelemetry is enabled
 
     // TLS default values
     public static final boolean DEFAULT_TLS_ENABLED = false; // Disabled by default for backwards compatibility
@@ -268,6 +270,7 @@ public class ServerConfiguration {
     private final boolean telemetryGrpcMetricsEnabled;
     private final boolean telemetryPoolMetricsEnabled;
     private final boolean telemetryCacheMetricsEnabled;
+    private final boolean telemetryCircuitBreakerMetricsEnabled;
 
     // TLS configuration
     private final boolean tlsEnabled;
@@ -376,6 +379,7 @@ public class ServerConfiguration {
         this.telemetryGrpcMetricsEnabled = getBooleanProperty(TELEMETRY_GRPC_METRICS_ENABLED_KEY, DEFAULT_TELEMETRY_GRPC_METRICS_ENABLED);
         this.telemetryPoolMetricsEnabled = getBooleanProperty(TELEMETRY_POOL_METRICS_ENABLED_KEY, DEFAULT_TELEMETRY_POOL_METRICS_ENABLED);
         this.telemetryCacheMetricsEnabled = getBooleanProperty(TELEMETRY_CACHE_METRICS_ENABLED_KEY, DEFAULT_TELEMETRY_CACHE_METRICS_ENABLED);
+        this.telemetryCircuitBreakerMetricsEnabled = getBooleanProperty(TELEMETRY_CIRCUIT_BREAKER_ENABLED_KEY, DEFAULT_TELEMETRY_CIRCUIT_BREAKER_ENABLED);
 
         // ResultSet streaming configuration
         this.resultsetRowsPerBlock = getBoundedIntProperty(RESULTSET_ROWS_PER_BLOCK_KEY, DEFAULT_RESULTSET_ROWS_PER_BLOCK,
@@ -939,6 +943,10 @@ public class ServerConfiguration {
 
     public boolean isTelemetryPoolMetricsEnabled() {
         return telemetryPoolMetricsEnabled;
+    }
+
+    public boolean isTelemetryCircuitBreakerMetricsEnabled() {
+        return telemetryCircuitBreakerMetricsEnabled;
     }
 
     public boolean isTelemetryCacheMetricsEnabled() {

--- a/ojp-server/src/test/java/org/openjproxy/grpc/server/CircuitBreakerTest.java
+++ b/ojp-server/src/test/java/org/openjproxy/grpc/server/CircuitBreakerTest.java
@@ -43,7 +43,7 @@ class CircuitBreakerTest {
     }
 
     @Test
-    void testAllowsAgainAfterOpenTimeoutAndSuccessResets() throws SQLException {
+    void testAllowsAgainAfterOpenTimeoutAndSuccessResets() {
         TestTicker ticker = new TestTicker();
         CircuitBreaker breaker = new CircuitBreaker(
                 THREE_HUNDRED,
@@ -70,7 +70,7 @@ class CircuitBreakerTest {
     }
 
     @Test
-    void testResetsOnSuccess() throws SQLException {
+    void testResetsOnSuccess() {
         CircuitBreaker breaker = new CircuitBreaker(THOUSAND, FAILURE_THRESHOLD, DATA_SOURCE);
         String sql = "INSERT X";
         SQLException ex = new SQLException("fail2");

--- a/ojp-server/src/test/java/org/openjproxy/grpc/server/CircuitBreakerTest.java
+++ b/ojp-server/src/test/java/org/openjproxy/grpc/server/CircuitBreakerTest.java
@@ -1,12 +1,17 @@
 package org.openjproxy.grpc.server;
 
+import io.opentelemetry.api.OpenTelemetry;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CircuitBreakerTest {
     private static final int THOUSAND = 1000;
@@ -15,7 +20,7 @@ class CircuitBreakerTest {
     private static final int FOUR_HUNDRED = 400;
     private static final int FIVE_HUNDRED = 500;
     private static final String DATA_SOURCE = "Test-DS";
-    
+
 
     @Test
     void testAllowsWhenNoFailures() {
@@ -38,8 +43,15 @@ class CircuitBreakerTest {
     }
 
     @Test
-    void testAllowsAgainAfterOpenTimeoutAndSuccessResets() throws InterruptedException, SQLException {
-        CircuitBreaker breaker = new CircuitBreaker(THREE_HUNDRED, FAILURE_THRESHOLD, DATA_SOURCE);
+    void testAllowsAgainAfterOpenTimeoutAndSuccessResets() throws SQLException {
+        TestTicker ticker = new TestTicker();
+        CircuitBreaker breaker = new CircuitBreaker(
+                THREE_HUNDRED,
+                FAILURE_THRESHOLD,
+                DATA_SOURCE,
+                CircuitBreakerMetrics.noop(),
+                ticker::nanoTime
+        );
         String sql = "UPDATE X SET Y=1";
         SQLException ex = new SQLException("fail");
 
@@ -49,8 +61,7 @@ class CircuitBreakerTest {
         breaker.onFailure(sql, ex);
         assertThrows(SQLException.class, () -> breaker.preCheck(sql));
 
-        // Wait for open period to pass
-        Thread.sleep(FOUR_HUNDRED);
+        ticker.advanceMillis(FOUR_HUNDRED);
         // Should allow one through (half-open)
         assertDoesNotThrow(() -> breaker.preCheck(sql));
         // Success should reset
@@ -87,5 +98,112 @@ class CircuitBreakerTest {
 
         SQLException thrown = assertThrows(SQLException.class, () -> breaker.preCheck(sql));
         assertEquals("fail1", thrown.getMessage());
+    }
+
+    @Test
+    void testRecordsCircuitBreakerMetricsLifecycle() {
+        TestTicker ticker = new TestTicker();
+        RecordingCircuitBreakerMetrics metrics = new RecordingCircuitBreakerMetrics();
+        CircuitBreaker breaker = new CircuitBreaker(
+                THREE_HUNDRED,
+                FAILURE_THRESHOLD,
+                DATA_SOURCE,
+                metrics,
+                ticker::nanoTime
+        );
+        String sql = "SELECT metrics";
+        SQLException ex = new SQLException("fail");
+
+        breaker.onFailure(sql, ex);
+        breaker.onFailure(sql, ex);
+        breaker.onFailure(sql, ex);
+
+        assertEquals(2, metrics.countState(CircuitBreakerMetrics.State.CLOSED));
+        assertTrue(metrics.hasStateUpdate(
+                DATA_SOURCE,
+                sql,
+                CircuitBreakerMetrics.State.OPEN,
+                CircuitBreakerMetrics.TripReason.FAILURE_THRESHOLD
+        ));
+
+        assertThrows(SQLException.class, () -> breaker.preCheck(sql));
+        assertEquals(List.of(metricKey(DATA_SOURCE, sql)), metrics.blockedCalls);
+
+        ticker.advanceMillis(FOUR_HUNDRED);
+        assertDoesNotThrow(() -> breaker.preCheck(sql));
+        assertTrue(metrics.hasStateUpdate(DATA_SOURCE, sql, CircuitBreakerMetrics.State.HALF_OPEN, null));
+
+        breaker.onSuccess(sql);
+        assertEquals(3, metrics.countState(CircuitBreakerMetrics.State.CLOSED));
+    }
+
+    private static String metricKey(String datasource, String queryHash) {
+        return datasource + "|" + queryHash;
+    }
+
+    private static String stateMetricKey(
+            String datasource,
+            String queryHash,
+            CircuitBreakerMetrics.State state,
+            CircuitBreakerMetrics.TripReason reason
+    ) {
+        return String.join(
+                "|",
+                datasource,
+                queryHash,
+                state.name(),
+                reason == null ? "NONE" : reason.name()
+        );
+    }
+
+    private static final class RecordingCircuitBreakerMetrics extends CircuitBreakerMetrics {
+        private final List<String> stateUpdates = new ArrayList<>();
+        private final List<String> blockedCalls = new ArrayList<>();
+
+        private RecordingCircuitBreakerMetrics() {
+            super(OpenTelemetry.noop());
+        }
+
+        @Override
+        public void updateState(String datasource, String queryHash, State newState) {
+            stateUpdates.add(stateMetricKey(datasource, queryHash, newState, null));
+        }
+
+        @Override
+        public void updateState(String datasource, String queryHash, State newState, TripReason tripReason) {
+            stateUpdates.add(stateMetricKey(datasource, queryHash, newState, tripReason));
+        }
+
+        @Override
+        public void recordBlockedCall(String datasource, String queryHash) {
+            blockedCalls.add(metricKey(datasource, queryHash));
+        }
+
+        private long countState(CircuitBreakerMetrics.State state) {
+            return stateUpdates.stream()
+                    .filter(update -> update.contains("|" + state.name() + "|"))
+                    .count();
+        }
+
+        private boolean hasStateUpdate(
+                String datasource,
+                String queryHash,
+                CircuitBreakerMetrics.State state,
+                CircuitBreakerMetrics.TripReason reason
+        ) {
+            return stateUpdates.contains(stateMetricKey(datasource, queryHash, state, reason));
+        }
+    }
+
+    private static final class TestTicker {
+        private long currentNanos;
+
+        private long nanoTime() {
+            return currentNanos;
+        }
+
+        private void advanceMillis(long millis) {
+            currentNanos += TimeUnit.MILLISECONDS.toNanos(millis);
+        }
     }
 }

--- a/ojp-server/src/test/java/org/openjproxy/grpc/server/OjpServerTelemetryTest.java
+++ b/ojp-server/src/test/java/org/openjproxy/grpc/server/OjpServerTelemetryTest.java
@@ -49,24 +49,24 @@ class OjpServerTelemetryTest {
 		assertEquals("text/plain; version=0.0.4; charset=utf-8", connection.getContentType());
 	}
 
-    @Test
-    void shouldCreateNoOpGrpcTelemetryWhenDisabled() {
-        OjpServerTelemetry noOpTelemetry = new OjpServerTelemetry();
-        GrpcTelemetry noOp = noOpTelemetry.createNoOpGrpcTelemetry();
+	@Test
+	void shouldCreateNoOpGrpcTelemetryWhenDisabled() {
+		OjpServerTelemetry noOpTelemetry = new OjpServerTelemetry();
+		GrpcTelemetry noOp = noOpTelemetry.createNoOpGrpcTelemetry();
 
-        assertNotNull(noOp);
-        assertNotNull(noOp.newServerInterceptor());
+		assertNotNull(noOp);
+		assertNotNull(noOp.newServerInterceptor());
 		assertNotNull(noOp.newClientInterceptor());
 	}
 
-    @Test
-    void shouldCreateGrpcTelemetryWithTracingDisabledByDefault() {
-        OjpServerTelemetry telemetryFactory = new OjpServerTelemetry();
-        // tracing disabled — no exporter is configured; must not throw
-        GrpcTelemetry telemetry = telemetryFactory.createGrpcTelemetry(
-                9192,
-                List.of(IpWhitelistValidator.ALLOW_ALL_IPS),
-                false, "zipkin", "http://localhost:9411/api/v2/spans", "ojp-server", 1.0,
+	@Test
+	void shouldCreateGrpcTelemetryWithTracingDisabledByDefault() {
+		OjpServerTelemetry telemetryFactory = new OjpServerTelemetry();
+		// tracing disabled - no exporter is configured; must not throw
+		GrpcTelemetry telemetry = telemetryFactory.createGrpcTelemetry(
+				9192,
+				List.of(IpWhitelistValidator.ALLOW_ALL_IPS),
+				false, "zipkin", "http://localhost:9411/api/v2/spans", "ojp-server", 1.0,
 				true, true); // grpcMetricsEnabled, poolMetricsEnabled
 
 		assertNotNull(telemetry);

--- a/ojp-server/src/test/java/org/openjproxy/grpc/server/OjpServerTelemetryTest.java
+++ b/ojp-server/src/test/java/org/openjproxy/grpc/server/OjpServerTelemetryTest.java
@@ -17,11 +17,12 @@ class OjpServerTelemetryTest {
 	private static final int TIMEOUT = 5000;
 	private static final int RESPONSE_CODE_OK = 200;
 
+	private static OjpServerTelemetry instrument;
 	private static GrpcTelemetry grpcTelemetry;
 
 	@BeforeAll
 	static void setUp() {
-		OjpServerTelemetry instrument = new OjpServerTelemetry();
+		instrument = new OjpServerTelemetry();
 		grpcTelemetry = instrument.createGrpcTelemetry(PROMETHEUS_PORT);
 	}
 
@@ -30,6 +31,11 @@ class OjpServerTelemetryTest {
 		assertNotNull(grpcTelemetry);
 		assertNotNull(grpcTelemetry.newServerInterceptor());
 		assertNotNull(grpcTelemetry.newClientInterceptor());
+	}
+
+	@Test
+	void shouldCreateCircuitBreakerMetricsWithServerTelemetry() {
+		assertNotNull(instrument.createCircuitBreakerMetrics());
 	}
 
 	@Test
@@ -43,24 +49,24 @@ class OjpServerTelemetryTest {
 		assertEquals("text/plain; version=0.0.4; charset=utf-8", connection.getContentType());
 	}
 
-	@Test
-	void shouldCreateNoOpGrpcTelemetryWhenDisabled() {
-		OjpServerTelemetry instrument = new OjpServerTelemetry();
-		GrpcTelemetry noOp = instrument.createNoOpGrpcTelemetry();
+    @Test
+    void shouldCreateNoOpGrpcTelemetryWhenDisabled() {
+        OjpServerTelemetry noOpTelemetry = new OjpServerTelemetry();
+        GrpcTelemetry noOp = noOpTelemetry.createNoOpGrpcTelemetry();
 
-		assertNotNull(noOp);
-		assertNotNull(noOp.newServerInterceptor());
+        assertNotNull(noOp);
+        assertNotNull(noOp.newServerInterceptor());
 		assertNotNull(noOp.newClientInterceptor());
 	}
 
-	@Test
-	void shouldCreateGrpcTelemetryWithTracingDisabledByDefault() {
-		OjpServerTelemetry instrument = new OjpServerTelemetry();
-		// tracing disabled — no exporter is configured; must not throw
-		GrpcTelemetry telemetry = instrument.createGrpcTelemetry(
-				9192,
-				List.of(IpWhitelistValidator.ALLOW_ALL_IPS),
-				false, "zipkin", "http://localhost:9411/api/v2/spans", "ojp-server", 1.0,
+    @Test
+    void shouldCreateGrpcTelemetryWithTracingDisabledByDefault() {
+        OjpServerTelemetry telemetryFactory = new OjpServerTelemetry();
+        // tracing disabled — no exporter is configured; must not throw
+        GrpcTelemetry telemetry = telemetryFactory.createGrpcTelemetry(
+                9192,
+                List.of(IpWhitelistValidator.ALLOW_ALL_IPS),
+                false, "zipkin", "http://localhost:9411/api/v2/spans", "ojp-server", 1.0,
 				true, true); // grpcMetricsEnabled, poolMetricsEnabled
 
 		assertNotNull(telemetry);

--- a/ojp-server/src/test/java/org/openjproxy/grpc/server/ServerConfigurationTest.java
+++ b/ojp-server/src/test/java/org/openjproxy/grpc/server/ServerConfigurationTest.java
@@ -2,6 +2,9 @@ package org.openjproxy.grpc.server;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
@@ -76,7 +79,6 @@ class ServerConfigurationTest {
         assertEquals(ServerConfiguration.DEFAULT_SLOW_QUERY_BASELINE_REFRESH_INTERVAL_SECONDS,
                 config.getSlowQueryBaselineRefreshIntervalSeconds());
         assertEquals(ServerConfiguration.DEFAULT_CIRCUIT_BREAKER_THRESHOLD, config.getCircuitBreakerThreshold());
-        assertEquals(ServerConfiguration.DEFAULT_DRIVERS_PATH, config.getDriversPath());
         assertTrue(config.isStatementCacheEnabled());
         assertEquals(250, config.getStatementCacheMaxSize());
         assertEquals(2048, config.getStatementCacheSqlLimit());
@@ -398,63 +400,24 @@ class ServerConfigurationTest {
         assertEquals(ServerConfiguration.DEFAULT_RESULTSET_ROWS_PER_BLOCK, config.getResultsetRowsPerBlock());
     }
 
-    @Test
-    void testResultsetRowsPerBlockCustomValue() {
-        System.setProperty("ojp.resultset.rowsPerBlock", "250");
+    @ParameterizedTest
+    @CsvSource({
+            "250, 250",
+            "1, 1",
+            "10000, 10000"
+    })
+    void testResultsetRowsPerBlockValidValues(String propertyValue, int expectedRowsPerBlock) {
+        System.setProperty("ojp.resultset.rowsPerBlock", propertyValue);
 
         ServerConfiguration config = new ServerConfiguration();
 
-        assertEquals(250, config.getResultsetRowsPerBlock());
+        assertEquals(expectedRowsPerBlock, config.getResultsetRowsPerBlock());
     }
 
-    @Test
-    void testResultsetRowsPerBlockMinimumBoundary() {
-        System.setProperty("ojp.resultset.rowsPerBlock", "1");
-
-        ServerConfiguration config = new ServerConfiguration();
-
-        assertEquals(1, config.getResultsetRowsPerBlock());
-    }
-
-    @Test
-    void testResultsetRowsPerBlockMaximumBoundary() {
-        System.setProperty("ojp.resultset.rowsPerBlock", "10000");
-
-        ServerConfiguration config = new ServerConfiguration();
-
-        assertEquals(10000, config.getResultsetRowsPerBlock());
-    }
-
-    @Test
-    void testResultsetRowsPerBlockBelowMinimumFallsBackToDefault() {
-        System.setProperty("ojp.resultset.rowsPerBlock", "0");
-
-        ServerConfiguration config = new ServerConfiguration();
-
-        assertEquals(ServerConfiguration.DEFAULT_RESULTSET_ROWS_PER_BLOCK, config.getResultsetRowsPerBlock());
-    }
-
-    @Test
-    void testResultsetRowsPerBlockAboveMaximumFallsBackToDefault() {
-        System.setProperty("ojp.resultset.rowsPerBlock", "10001");
-
-        ServerConfiguration config = new ServerConfiguration();
-
-        assertEquals(ServerConfiguration.DEFAULT_RESULTSET_ROWS_PER_BLOCK, config.getResultsetRowsPerBlock());
-    }
-
-    @Test
-    void testResultsetRowsPerBlockNegativeValueFallsBackToDefault() {
-        System.setProperty("ojp.resultset.rowsPerBlock", "-1");
-
-        ServerConfiguration config = new ServerConfiguration();
-
-        assertEquals(ServerConfiguration.DEFAULT_RESULTSET_ROWS_PER_BLOCK, config.getResultsetRowsPerBlock());
-    }
-
-    @Test
-    void testResultsetRowsPerBlockInvalidStringFallsBackToDefault() {
-        System.setProperty("ojp.resultset.rowsPerBlock", "not-a-number");
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "10001", "-1", "not-a-number"})
+    void testResultsetRowsPerBlockInvalidValuesFallBackToDefault(String propertyValue) {
+        System.setProperty("ojp.resultset.rowsPerBlock", propertyValue);
 
         ServerConfiguration config = new ServerConfiguration();
 

--- a/ojp-server/src/test/java/org/openjproxy/grpc/server/ServerConfigurationTest.java
+++ b/ojp-server/src/test/java/org/openjproxy/grpc/server/ServerConfigurationTest.java
@@ -28,6 +28,7 @@ class ServerConfigurationTest {
         System.clearProperty("ojp.server.allowedIps");
         System.clearProperty("ojp.server.connectionIdleTimeout");
         System.clearProperty("ojp.prometheus.allowedIps");
+        System.clearProperty("ojp.telemetry.circuitbreaker.enabled");
         System.clearProperty("ojp.server.circuitBreakerTimeout");
         System.clearProperty("ojp.server.maxConcurrentRequests");
         System.clearProperty("ojp.server.admissionControl.maxQueueDepth");
@@ -61,6 +62,8 @@ class ServerConfigurationTest {
         assertEquals(ServerConfiguration.DEFAULT_CONNECTION_IDLE_TIMEOUT, config.getConnectionIdleTimeout());
         assertEquals(ServerConfiguration.DEFAULT_PROMETHEUS_ALLOWED_IPS, config.getPrometheusAllowedIps());
         assertEquals(ServerConfiguration.DEFAULT_CIRCUIT_BREAKER_TIMEOUT, config.getCircuitBreakerTimeout());
+        assertEquals(ServerConfiguration.DEFAULT_TELEMETRY_CIRCUIT_BREAKER_ENABLED,
+                config.isTelemetryCircuitBreakerMetricsEnabled());
         assertEquals(ServerConfiguration.DEFAULT_MAX_CONCURRENT_REQUESTS, config.getMaxConcurrentRequests());
         assertEquals(ServerConfiguration.DEFAULT_ADMISSION_CONTROL_MAX_QUEUE_DEPTH, config.getAdmissionControlMaxQueueDepth());
         assertEquals(ServerConfiguration.DEFAULT_SLOW_QUERY_CLASSIFICATION_MODE, config.getSlowQueryClassificationMode());
@@ -120,6 +123,17 @@ class ServerConfigurationTest {
         assertEquals(120000, config.getCircuitBreakerTimeout());
         assertEquals(123, config.getMaxConcurrentRequests());
         assertEquals(77, config.getAdmissionControlMaxQueueDepth());
+    }
+
+    @Test
+    void testCanDisableCircuitBreakerMetricsIndependently() {
+        System.setProperty("ojp.telemetry.enabled", "true");
+        System.setProperty("ojp.telemetry.circuitbreaker.enabled", "false");
+
+        ServerConfiguration config = new ServerConfiguration();
+
+        assertTrue(config.isOpenTelemetryEnabled());
+        assertFalse(config.isTelemetryCircuitBreakerMetricsEnabled());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds OpenTelemetry metrics for circuit breaker behavior and exposes them through the existing Prometheus telemetry pipeline.

## Changes

- Add `CircuitBreakerMetrics` for:
  - current circuit state
  - state transitions
  - circuit trips
  - blocked calls
  - open duration
- Wire circuit breaker metrics into `CircuitBreaker`, `CircuitBreakerRegistry`, and `GrpcServer`
- Reuse the server `OpenTelemetry` instance from `OjpServerTelemetry`
- Document metric names, labels, Prometheus queries, and Grafana examples
- Add tests for circuit breaker metrics lifecycle and telemetry integration
