### PR TITLE
running jdeps during image build to avoid missing modules

### DIFF
--- a/ojp-server/Dockerfile
+++ b/ojp-server/Dockerfile
@@ -1,13 +1,18 @@
 # Stage 1: Build custom JRE with jlink
+# jdeps analyses the fat JAR to compute the exact set of JDK modules required,
+# so the module list never drifts out of sync when new dependencies are added.
 FROM eclipse-temurin:25-jdk-alpine AS jre-build
 
-RUN jlink \
-    --add-modules java.base,java.compiler,java.desktop,java.management,java.naming,java.rmi,java.scripting,java.security.jgss,java.sql,jdk.httpserver,jdk.unsupported \
-    --strip-debug \
-    --no-man-pages \
-    --no-header-files \
-    --compress=zip-6 \
-    --output /custom-jre
+COPY target/ojp-server-*-shaded.jar /tmp/ojp-server.jar
+
+RUN MODULES=$(jdeps --ignore-missing-deps --print-module-deps /tmp/ojp-server.jar) && \
+    jlink \
+        --add-modules ${MODULES} \
+        --strip-debug \
+        --no-man-pages \
+        --no-header-files \
+        --compress=zip-6 \
+        --output /custom-jre
 
 # Stage 2: Runtime image
 FROM alpine:3.21


### PR DESCRIPTION
Running jdeps to always get an up-to-date list of required modules, avoid missing modules and eventually throwing `ClassNotFound`-like exceptions
Closes https://github.com/Open-J-Proxy/ojp/issues/550