### PR TITLE
feat: add per-datasource HikariCP leakDetectionThreshold configuration

### DIFF
--- a/documents/configuration/ojp-server-configuration.md
+++ b/documents/configuration/ojp-server-configuration.md
@@ -180,6 +180,12 @@ Controls how the server batches rows into gRPC streaming messages when returning
 - The default of 100 matches the historical behaviour and is a safe starting point for most workloads.
 - Values below 1 or above 10000 are rejected and the default is used instead.
 
+### Connection Pool Settings
+
+| Property                                       | Environment Variable                           | Type | Default | Description                                       | Since |
+|-------------------------------------------------|-------------------------------------------------|------|---------|-----------------------------------------------------|-------|
+| `ojp.connection.pool.leakDetectionThreshold`   | `OJP_CONNECTION_POOL_LEAKDETECTIONTHRESHOLD`   | long | 0       | HikariCP leak detection threshold (ms). `0` = disabled. Leave at `0` unless diagnosing abandoned sessions — OJP holds one physical connection per client session by design, so any non-zero value will produce false-positive warnings for long-lived sessions (e.g. SQL IDEs). | 0.5.4-SNAPSHOT |
+
 ### Slow Query Segregation Settings
 
 | Property                                           | Environment Variable                               | Type    | Default  | Description                                      | Since |

--- a/documents/configuration/ojp-server-example.properties
+++ b/documents/configuration/ojp-server-example.properties
@@ -108,6 +108,10 @@ ojp.server.slowQuerySegregation.slowQueryThresholdMs=1000
 # different client sessions.
 # ============================================================================
 
+# Leak detection threshold in ms. 0 = disabled (default). Enable only to diagnose
+# genuinely abandoned sessions; OJP holds one connection per session by design.
+#ojp.connection.pool.leakDetectionThreshold=0
+
 
 # ============================================================================
 # TLS/mTLS Configuration

--- a/documents/ebook/appendix-g-troubleshooting.md
+++ b/documents/ebook/appendix-g-troubleshooting.md
@@ -812,7 +812,7 @@ When one pool exhausts its connections, it can trigger exhaustion in other pools
 **Prevention strategies**:
 - Configure appropriate maximum pool sizes: `hikariCP.maximumPoolSize`
 - Implement connection acquisition timeouts: `hikariCP.connectionTimeout=30000`
-- Use HikariCP's leak detection: `hikariCP.leakDetectionThreshold=300000`
+- Use HikariCP's leak detection: `ojp.connection.pool.leakDetectionThreshold=300000` (note: enabling this in OJP may produce false-positive warnings for normal long-lived client sessions, since OJP holds one connection per session by design)
 - Deploy sufficient OJP server capacity with headroom for traffic spikes
 - Implement application-level retry limits to prevent request amplification
 
@@ -1103,8 +1103,11 @@ Applications that don't close connections exhaust connection pools, causing new 
 
 **Detection**:
 ```properties
-# Enable HikariCP leak detection
-hikariCP.leakDetectionThreshold=60000  # 60 seconds
+# Enable HikariCP leak detection (default: 0 = disabled)
+# Note: enabling this in OJP may produce false-positive warnings for normal
+# long-lived sessions, since OJP intentionally holds one connection per
+# client session for the entire session lifetime by design.
+ojp.connection.pool.leakDetectionThreshold=60000  # 60 seconds
 ```
 
 Leaked connections appear in logs:

--- a/documents/ebook/part2-chapter6-server-configuration.md
+++ b/documents/ebook/part2-chapter6-server-configuration.md
@@ -559,6 +559,14 @@ Each replica has its own connection pool. Size it to handle peak read traffic in
 
 For the complete property reference see [OJP JDBC Configuration — Read/Write Splitting](../../documents/configuration/ojp-jdbc-configuration.md#readwrite-splitting-configuration).
 
+### 6.8.5 Connection Pool Leak Detection
+
+| Property | Default | Description |
+|---|---|---|
+| `ojp.connection.pool.leakDetectionThreshold` | `0` | HikariCP leak detection threshold (ms). `0` = disabled. |
+
+The default is `0` (disabled) because OJP intentionally holds one physical connection per client session for the entire lifetime of that session — that's the whole point of the proxy. HikariCP's leak detector, however, is designed around the assumption that connections are borrowed and returned quickly, so enabling it produces false-positive "leak" warnings for tools with long-lived sessions (e.g. SQL IDEs). Only set this to a non-zero value temporarily, when you need to diagnose genuinely abandoned sessions, and turn it back off afterward.
+
 ## Summary
 
 OJP server configuration gives you precise control over server behavior, security, performance, and observability. The hierarchical configuration system with JVM properties and environment variables provides flexibility for different deployment scenarios. Default settings work well for most use cases, but understanding the available options lets you optimize for your specific workload.

--- a/ojp-datasource-api/src/main/java/org/openjproxy/datasource/PoolConfig.java
+++ b/ojp-datasource-api/src/main/java/org/openjproxy/datasource/PoolConfig.java
@@ -42,6 +42,7 @@ public final class PoolConfig {
     private final long connectionTimeoutMs;
     private final long idleTimeoutMs;
     private final long maxLifetimeMs;
+    private final long leakDetectionThresholdMs;
 
     // Validation and behavior settings
     private final String validationQuery;
@@ -61,6 +62,10 @@ public final class PoolConfig {
     public static final long DEFAULT_IDLE_TIMEOUT_MS = 600000L;
     public static final long DEFAULT_MAX_LIFETIME_MS = 1800000L;
     public static final boolean DEFAULT_AUTO_COMMIT = true;
+    // 0 disables HikariCP's leak detection. OJP intentionally holds one physical connection
+    // per client session for the session's full lifetime, so a non-zero default would produce
+    // false-positive "leak" warnings for long-lived client sessions (e.g. SQL IDEs).
+    public static final long DEFAULT_LEAK_DETECTION_THRESHOLD_MS = 0L;
 
     private PoolConfig(Builder builder) {
         this.url = builder.url;
@@ -73,6 +78,7 @@ public final class PoolConfig {
         this.connectionTimeoutMs = builder.connectionTimeoutMs;
         this.idleTimeoutMs = builder.idleTimeoutMs;
         this.maxLifetimeMs = builder.maxLifetimeMs;
+        this.leakDetectionThresholdMs = builder.leakDetectionThresholdMs;
         this.validationQuery = builder.validationQuery;
         this.autoCommit = builder.autoCommit;
         this.defaultTransactionIsolation = builder.defaultTransactionIsolation;
@@ -198,6 +204,23 @@ public final class PoolConfig {
     }
 
     /**
+     * Gets the leak detection threshold in milliseconds.
+     * When a connection is held (checked out from the pool) longer than this
+     * threshold, HikariCP logs a warning with a stack trace of where it was acquired.
+     *
+     * <p>A value of {@code 0} disables leak detection. This is the default because
+     * OJP intentionally holds one physical connection per client session for the
+     * session's full lifetime, which can legitimately exceed typical leak-detection
+     * windows for long-lived client tools (e.g. SQL IDEs). Enabling this is mainly
+     * useful for diagnosing genuinely abandoned sessions.</p>
+     *
+     * @return the leak detection threshold in milliseconds, or 0 if disabled
+     */
+    public long getLeakDetectionThresholdMs() {
+        return leakDetectionThresholdMs;
+    }
+
+    /**
      * Gets the SQL query used to validate connections.
      *
      * @return the validation query, may be null if not configured
@@ -266,6 +289,7 @@ public final class PoolConfig {
                 ", connectionTimeoutMs=" + connectionTimeoutMs +
                 ", idleTimeoutMs=" + idleTimeoutMs +
                 ", maxLifetimeMs=" + maxLifetimeMs +
+                ", leakDetectionThresholdMs=" + leakDetectionThresholdMs +
                 ", validationQuery='" + validationQuery + '\'' +
                 ", autoCommit=" + autoCommit +
                 ", defaultTransactionIsolation=" + defaultTransactionIsolation +
@@ -288,6 +312,7 @@ public final class PoolConfig {
         private long connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS;
         private long idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS;
         private long maxLifetimeMs = DEFAULT_MAX_LIFETIME_MS;
+        private long leakDetectionThresholdMs = DEFAULT_LEAK_DETECTION_THRESHOLD_MS;
         private String validationQuery;
         private boolean autoCommit = DEFAULT_AUTO_COMMIT;
         private Integer defaultTransactionIsolation;
@@ -443,6 +468,21 @@ public final class PoolConfig {
                 throw new IllegalArgumentException("maxLifetimeMs cannot be negative");
             }
             this.maxLifetimeMs = maxLifetimeMs;
+            return this;
+        }
+
+        /**
+         * Sets the leak detection threshold in milliseconds.
+         *
+         * @param leakDetectionThresholdMs the threshold in milliseconds, or 0 to disable leak detection
+         * @return this builder
+         * @throws IllegalArgumentException if leakDetectionThresholdMs is negative
+         */
+        public Builder leakDetectionThresholdMs(long leakDetectionThresholdMs) {
+            if (leakDetectionThresholdMs < 0) {
+                throw new IllegalArgumentException("leakDetectionThresholdMs cannot be negative");
+            }
+            this.leakDetectionThresholdMs = leakDetectionThresholdMs;
             return this;
         }
 

--- a/ojp-datasource-hikari/src/main/java/org/openjproxy/datasource/hikari/HikariConnectionPoolProvider.java
+++ b/ojp-datasource-hikari/src/main/java/org/openjproxy/datasource/hikari/HikariConnectionPoolProvider.java
@@ -121,7 +121,7 @@ public class HikariConnectionPoolProvider implements ConnectionPoolProvider {
         hikariConfig.setPoolName(poolName);
 
         // Additional HikariCP-specific settings for production use
-        hikariConfig.setLeakDetectionThreshold(60000); // 60 seconds
+        hikariConfig.setLeakDetectionThreshold(config.getLeakDetectionThresholdMs()); // 0 = disabled (default)
         hikariConfig.setValidationTimeout(5000);       // 5 seconds
         hikariConfig.setInitializationFailTimeout(10000); // 10 seconds
         hikariConfig.setRegisterMbeans(true);

--- a/ojp-grpc-commons/src/main/java/org/openjproxy/constants/CommonConstants.java
+++ b/ojp-grpc-commons/src/main/java/org/openjproxy/constants/CommonConstants.java
@@ -34,6 +34,7 @@ public class CommonConstants {
     public static final String MAX_LIFETIME_PROPERTY = "ojp.connection.pool.maxLifetime";
     public static final String CONNECTION_TIMEOUT_PROPERTY = "ojp.connection.pool.connectionTimeout";
     public static final String POOL_ENABLED_PROPERTY = "ojp.connection.pool.enabled";
+    public static final String LEAK_DETECTION_THRESHOLD_PROPERTY = "ojp.connection.pool.leakDetectionThreshold";
 
     // XA-specific pool configuration property keys
     public static final String XA_MAXIMUM_POOL_SIZE_PROPERTY = "ojp.xa.connection.pool.maximumPoolSize";
@@ -81,6 +82,13 @@ public class CommonConstants {
     public static final long DEFAULT_MAX_LIFETIME = 1800000; // 30 minutes
     public static final long DEFAULT_CONNECTION_TIMEOUT = 10000; // Reduced from 30s to 10s for faster failure
     public static final long FAIL_FAST_POOL_CONNECTION_TIMEOUT_MS = 1L; // HikariCP clamps this to 250ms minimum; semaphore gatekeeper enforces the wait budget
+    // OJP intentionally holds one physical connection per client session for the session's whole
+    // lifetime (that is the point of the proxy), which can legitimately exceed HikariCP's typical
+    // leak-detection windows for long-lived client tools (e.g. SQL IDEs). Disabled by default to
+    // avoid false-positive "leak" warnings; OJP's own idle-session cleanup already reclaims
+    // abandoned sessions. Set ojp.connection.pool.leakDetectionThreshold to a positive value (ms)
+    // to opt back into HikariCP's diagnostic leak detection.
+    public static final long DEFAULT_LEAK_DETECTION_THRESHOLD = 0L; // 0 = disabled
 
     // Prepared statement cache defaults (global server-side)
     public static final boolean DEFAULT_STATEMENT_CACHE_ENABLED = true;

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/action/connection/ConnectAction.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/action/connection/ConnectAction.java
@@ -219,6 +219,7 @@ public class ConnectAction implements Action<ConnectionDetails, SessionInfo> {
                                 .connectionTimeoutMs(CommonConstants.FAIL_FAST_POOL_CONNECTION_TIMEOUT_MS)
                                 .idleTimeoutMs(dsConfig.getIdleTimeout())
                                 .maxLifetimeMs(dsConfig.getMaxLifetime())
+                                .leakDetectionThresholdMs(dsConfig.getLeakDetectionThreshold())
                                 .defaultTransactionIsolation(defaultTransactionIsolation)
                                 .properties(statementCacheProperties)
                                 .metricsPrefix("OJP-Pool-" + dsConfig.getDataSourceName())

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/pool/DataSourceConfigurationManager.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/pool/DataSourceConfigurationManager.java
@@ -31,6 +31,7 @@ public class DataSourceConfigurationManager {
         private final long connectionTimeout;
         private final boolean poolEnabled;
         private final Integer defaultTransactionIsolation;
+        private final long leakDetectionThreshold;
 
         public DataSourceConfiguration(String dataSourceName, Properties properties) {
             this.dataSourceName = dataSourceName;
@@ -41,6 +42,7 @@ public class DataSourceConfigurationManager {
             this.connectionTimeout = getLongProperty(properties, CommonConstants.CONNECTION_TIMEOUT_PROPERTY, CommonConstants.DEFAULT_CONNECTION_TIMEOUT);
             this.poolEnabled = getBooleanProperty(properties, CommonConstants.POOL_ENABLED_PROPERTY, true);
             this.defaultTransactionIsolation = getTransactionIsolationProperty(properties, CommonConstants.DEFAULT_TRANSACTION_ISOLATION_PROPERTY);
+            this.leakDetectionThreshold = getLongProperty(properties, CommonConstants.LEAK_DETECTION_THRESHOLD_PROPERTY, CommonConstants.DEFAULT_LEAK_DETECTION_THRESHOLD);
         }
 
         // Getters
@@ -52,12 +54,13 @@ public class DataSourceConfigurationManager {
         public long getConnectionTimeout() { return connectionTimeout; }
         public boolean isPoolEnabled() { return poolEnabled; }
         public Integer getDefaultTransactionIsolation() { return defaultTransactionIsolation; }
+        public long getLeakDetectionThreshold() { return leakDetectionThreshold; }
 
         @Override
         public String toString() {
-            return String.format("DataSourceConfiguration[%s: maxPool=%d, minIdle=%d, timeout=%d, poolEnabled=%b, txIsolation=%s]",
+            return String.format("DataSourceConfiguration[%s: maxPool=%d, minIdle=%d, timeout=%d, poolEnabled=%b, txIsolation=%s, leakDetectionThreshold=%d]",
                     dataSourceName, maximumPoolSize, minimumIdle, connectionTimeout, poolEnabled,
-                    defaultTransactionIsolation != null ? defaultTransactionIsolation : "auto-detect");
+                    defaultTransactionIsolation != null ? defaultTransactionIsolation : "auto-detect", leakDetectionThreshold);
         }
     }
 
@@ -205,7 +208,8 @@ public class DataSourceConfigurationManager {
                     CommonConstants.MAX_LIFETIME_PROPERTY,
                     CommonConstants.CONNECTION_TIMEOUT_PROPERTY,
                     CommonConstants.POOL_ENABLED_PROPERTY,
-                    CommonConstants.DEFAULT_TRANSACTION_ISOLATION_PROPERTY
+                    CommonConstants.DEFAULT_TRANSACTION_ISOLATION_PROPERTY,
+                    CommonConstants.LEAK_DETECTION_THRESHOLD_PROPERTY
             };
         }
 


### PR DESCRIPTION
Previously HikariCP leak detection was hardcoded to 60 seconds. Since OJP intentionally keeps one physical connection per client session for the whole lifetime of the session (the whole point of the proxy), this produced false-positive "leak" warnings for tools with long-lived sessions (e.g. SQL IDEs).

The threshold is now configurable per datasource via the ojp.connection.pool.leakDetectionThreshold property (in ms), with 0 (disabled) as the new default. Added end-to-end support: constant in CommonConstants, field/getter/builder in PoolConfig, reading in DataSourceConfigurationManager, propagation in ConnectAction and usage in HikariConnectionPoolProvider.