### PR TITLE
fix: lastUpdateCount returning 0 instead of -1 after executeQuery causing an infinite spinner in DataGrip

### DIFF
--- a/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/PreparedStatement.java
+++ b/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/PreparedStatement.java
@@ -110,6 +110,7 @@ public class PreparedStatement extends Statement implements java.sql.PreparedSta
     public ResultSet executeQuery() throws SQLException {
         log.debug("executeQuery called");
         this.checkClosed();
+        this.lastUpdateCount = -1;
         log.info("Executing query for -> {}", this.sql);
         ClientThrottleManager throttle = this.connection.getThrottleManager();
         ClientThrottleMode mode = this.connection.getThrottleMode();

--- a/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/Statement.java
+++ b/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/Statement.java
@@ -40,7 +40,12 @@ public class Statement implements java.sql.Statement {
 
     protected boolean closed;
     protected ResultSet lastResultSet;
-    protected int lastUpdateCount;
+    // JDBC contract: -1 means "no update count" (i.e., the last executed statement returned a
+    // ResultSet, or no statement has been executed yet). 0 has a different, valid meaning
+    // ("an update statement affected 0 rows") and must never be used as the default here,
+    // otherwise callers relying on getUpdateCount()==-1 to detect "no more results" (e.g. DataGrip)
+    // will incorrectly believe another result is pending and hang waiting for it.
+    protected int lastUpdateCount = -1;
 
     public Statement(Connection connection, StatementService statementService) {
         this(connection, statementService, null);
@@ -123,6 +128,7 @@ public class Statement implements java.sql.Statement {
     public ResultSet executeQuery(String sql) throws SQLException {
         log.debug("executeQuery: {}", sql);
         checkClosed();
+        this.lastUpdateCount = -1;
         ClientThrottleManager throttle = this.connection.getThrottleManager();
         ClientThrottleMode mode = this.connection.getThrottleMode();
         // getAutoCommit() may throw SQLException; evaluate before acquiring a slot

--- a/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/H2PreparedStatementExtensiveTests.java
+++ b/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/H2PreparedStatementExtensiveTests.java
@@ -179,6 +179,49 @@ public class H2PreparedStatementExtensiveTests {
         try { ps.executeLargeUpdate(); } catch (Exception ignore) {}
     }
 
+    /**
+     * Regression test for PR #580: {@code getUpdateCount()} must return {@code -1} (not the
+     * implicit {@code int} default of {@code 0}) right after {@code executeQuery()} on a fresh
+     * {@link PreparedStatement}, otherwise clients relying on {@code getUpdateCount()==-1} to
+     * detect the end of result processing (e.g. DataGrip) believe an update result is still
+     * pending and hang.
+     */
+    @ParameterizedTest
+    @CsvFileSource(resources = "/h2_connection.csv")
+    void testGetUpdateCountIsMinusOneAfterExecuteQuery(String driverClass, String url, String user, String password) throws Exception {
+        this.setUp(driverClass, url, user, password);
+
+        ps = connection.prepareStatement("SELECT * FROM h2_prepared_stmt_test WHERE id = ?");
+        ps.setInt(1, 10);
+        try (ResultSet rs = ps.executeQuery()) {
+            assertEquals(-1, ps.getUpdateCount());
+        }
+    }
+
+    /**
+     * Regression test for PR #580: {@code execute()} on an UPDATE/INSERT sets a valid (>=0)
+     * update count, but {@code getUpdateCount()} on a different, freshly created
+     * {@link PreparedStatement} bound to a SELECT must still report {@code -1} rather than
+     * leaking the previous statement's update count via any shared state.
+     */
+    @ParameterizedTest
+    @CsvFileSource(resources = "/h2_connection.csv")
+    void testGetUpdateCountResetsToMinusOneWhenQueryFollowsAnUpdate(String driverClass, String url, String user, String password) throws Exception {
+        this.setUp(driverClass, url, user, password);
+
+        ps = connection.prepareStatement("INSERT INTO h2_prepared_stmt_test (id, name, age) VALUES (?, ?, ?)");
+        ps.setInt(1, 20); ps.setString(2, "Bob"); ps.setInt(3, 40);
+        boolean isResultSet = ps.execute();
+        assertFalse(isResultSet);
+        assertEquals(1, ps.getUpdateCount());
+
+        ps = connection.prepareStatement("SELECT * FROM h2_prepared_stmt_test WHERE id = ?");
+        ps.setInt(1, 20);
+        try (ResultSet rs = ps.executeQuery()) {
+            assertEquals(-1, ps.getUpdateCount());
+        }
+    }
+
     @ParameterizedTest
     @CsvFileSource(resources = "/h2_connection.csv")
     void testMetaDataAndWarnings(String driverClass, String url, String user, String password) throws Exception {

--- a/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/H2StatementExtensiveTests.java
+++ b/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/H2StatementExtensiveTests.java
@@ -58,6 +58,33 @@ public class H2StatementExtensiveTests {
 
     @ParameterizedTest
     @CsvFileSource(resources = "/h2_connection.csv")
+    void testGetUpdateCountIsMinusOneAfterExecuteQuery(String driverClass, String url, String user, String password) throws Exception {
+        // Regression test for PR #580: getUpdateCount() must return -1 (not 0) right after
+        // executeQuery(), otherwise clients relying on getUpdateCount()==-1 to detect the end
+        // of result processing (e.g. DataGrip) believe an update result is still pending.
+        this.setUp(driverClass, url, user, password);
+        ResultSet rs = statement.executeQuery("SELECT * FROM h2_statement_test");
+        assertEquals(-1, statement.getUpdateCount());
+        rs.close();
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/h2_connection.csv")
+    void testGetUpdateCountResetsToMinusOneWhenQueryFollowsAnUpdate(String driverClass, String url, String user, String password) throws Exception {
+        // Regression test for PR #580: execute() on an UPDATE sets a valid (>=0) update count,
+        // but a subsequent executeQuery() on the same Statement must reset it back to -1.
+        this.setUp(driverClass, url, user, password);
+        boolean isResultSet = statement.execute("UPDATE h2_statement_test SET name = 'Updated Alice' WHERE id = 1");
+        assertFalse(isResultSet);
+        assertEquals(1, statement.getUpdateCount());
+
+        ResultSet rs = statement.executeQuery("SELECT name FROM h2_statement_test WHERE id = 1");
+        assertEquals(-1, statement.getUpdateCount());
+        rs.close();
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/h2_connection.csv")
     void testExecuteUpdate(String driverClass, String url, String user, String password) throws Exception {
         this.setUp(driverClass, url, user, password);
         int rows = statement.executeUpdate("UPDATE h2_statement_test SET name = 'Updated Alice' WHERE id = 1");

--- a/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/FakeStatementService.java
+++ b/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/FakeStatementService.java
@@ -1,0 +1,163 @@
+package org.openjproxy.jdbc;
+
+import com.openjproxy.grpc.CallResourceRequest;
+import com.openjproxy.grpc.CallResourceResponse;
+import com.openjproxy.grpc.ConnectionDetails;
+import com.openjproxy.grpc.LobDataBlock;
+import com.openjproxy.grpc.LobReference;
+import com.openjproxy.grpc.OpResult;
+import com.openjproxy.grpc.SessionInfo;
+import org.openjproxy.grpc.client.StatementService;
+import org.openjproxy.grpc.dto.Parameter;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal {@link StatementService} test double used by unit tests that need to exercise
+ * {@link Statement} / {@link PreparedStatement} behaviour without a real gRPC server.
+ * Every method not overridden by the caller throws {@link UnsupportedOperationException}
+ * so accidental usage of unstubbed behaviour fails fast.
+ */
+class FakeStatementService implements StatementService {
+
+    private final OpResult executeUpdateResult;
+    private final Iterator<OpResult> executeQueryResult;
+
+    FakeStatementService() {
+        this(null, Collections.emptyIterator());
+    }
+
+    FakeStatementService(OpResult executeUpdateResult, Iterator<OpResult> executeQueryResult) {
+        this.executeUpdateResult = executeUpdateResult;
+        this.executeQueryResult = executeQueryResult;
+    }
+
+    @Override
+    public SessionInfo connect(ConnectionDetails connectionDetails) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OpResult executeUpdate(SessionInfo sessionInfo, String sql, List<Parameter> params,
+                                  Map<String, Object> properties) throws SQLException {
+        return this.executeUpdateResult;
+    }
+
+    @Override
+    public OpResult executeUpdate(SessionInfo sessionInfo, String sql, List<Parameter> params, String statementUUID,
+                                  Map<String, Object> properties) throws SQLException {
+        return this.executeUpdateResult;
+    }
+
+    @Override
+    public Iterator<OpResult> executeQuery(SessionInfo sessionInfo, String sql, List<Parameter> params,
+                                           String statementUUID, Map<String, Object> properties) throws SQLException {
+        return this.executeQueryResult;
+    }
+
+    @Override
+    public Iterator<OpResult> executeQuery(SessionInfo sessionInfo, String sql, List<Parameter> params,
+                                           Map<String, Object> properties) throws SQLException {
+        return this.executeQueryResult;
+    }
+
+    @Override
+    public OpResult fetchNextRows(SessionInfo sessionInfo, String resultSetUUID, int size) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LobReference createLob(Connection connection, Iterator<LobDataBlock> lobDataBlock) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator<LobDataBlock> readLob(LobReference lobReference, long pos, int length) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void terminateSession(SessionInfo session) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SessionInfo startTransaction(SessionInfo session) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SessionInfo commitTransaction(SessionInfo session) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SessionInfo rollbackTransaction(SessionInfo session) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CallResourceResponse callResource(CallResourceRequest request) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaResponse xaStart(com.openjproxy.grpc.XaStartRequest request) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaResponse xaEnd(com.openjproxy.grpc.XaEndRequest request) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaPrepareResponse xaPrepare(com.openjproxy.grpc.XaPrepareRequest request)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaResponse xaCommit(com.openjproxy.grpc.XaCommitRequest request) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaResponse xaRollback(com.openjproxy.grpc.XaRollbackRequest request)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaRecoverResponse xaRecover(com.openjproxy.grpc.XaRecoverRequest request)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaResponse xaForget(com.openjproxy.grpc.XaForgetRequest request) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaSetTransactionTimeoutResponse xaSetTransactionTimeout(
+            com.openjproxy.grpc.XaSetTransactionTimeoutRequest request) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaGetTransactionTimeoutResponse xaGetTransactionTimeout(
+            com.openjproxy.grpc.XaGetTransactionTimeoutRequest request) throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public com.openjproxy.grpc.XaIsSameRMResponse xaIsSameRM(com.openjproxy.grpc.XaIsSameRMRequest request)
+            throws SQLException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/PreparedStatementLastUpdateCountTest.java
+++ b/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/PreparedStatementLastUpdateCountTest.java
@@ -1,0 +1,120 @@
+package org.openjproxy.jdbc;
+
+import com.openjproxy.grpc.DbName;
+import com.openjproxy.grpc.OpQueryResultProto;
+import com.openjproxy.grpc.OpResult;
+import com.openjproxy.grpc.ResultType;
+import com.openjproxy.grpc.SessionInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for the {@code lastUpdateCount} JDBC contract on {@link PreparedStatement}.
+ *
+ * <p>Mirrors {@link StatementLastUpdateCountTest}: {@link java.sql.PreparedStatement#executeQuery()}
+ * must leave {@code getUpdateCount()} at {@code -1}, otherwise clients that check
+ * {@code getUpdateCount() == -1} to detect "no more results" (e.g. DataGrip) believe an update
+ * result is still pending and hang indefinitely. See PR #580.</p>
+ */
+class PreparedStatementLastUpdateCountTest {
+
+    // SessionInfo with an empty connHash so Connection#getThrottleManager() returns null and
+    // client-side throttling is bypassed entirely for these unit tests.
+    private static final SessionInfo SESSION = SessionInfo.newBuilder().setConnHash("").build();
+
+    @Test
+    void shouldReturnMinusOneByDefaultBeforeAnyStatementIsExecuted() throws Exception {
+        FakeStatementService fakeService = new FakeStatementService();
+        PreparedStatement statement = new PreparedStatement(newConnection(fakeService), "SELECT 1", fakeService);
+
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    @Test
+    void shouldReturnMinusOneAfterExecuteQuery() throws Exception {
+        FakeStatementService fakeService = new FakeStatementService(null, emptyQueryResult());
+        Connection connection = newConnection(fakeService);
+        PreparedStatement statement = new PreparedStatement(connection, "SELECT 1", fakeService);
+
+        statement.executeQuery();
+
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    @Test
+    void shouldReturnAffectedRowsFromExecuteUpdate() throws Exception {
+        // executeUpdate() returns the affected-row count directly; it does not touch
+        // lastUpdateCount (only execute()/executeQuery() do), so getUpdateCount() is
+        // intentionally not asserted here.
+        FakeStatementService fakeService = new FakeStatementService(updateResult(5), null);
+        Connection connection = newConnection(fakeService);
+        PreparedStatement statement = new PreparedStatement(connection, "UPDATE t SET x = ?", fakeService);
+
+        int affectedRows = statement.executeUpdate();
+
+        assertEquals(5, affectedRows);
+    }
+
+    @Test
+    void shouldResetToMinusOneWhenExecuteQueryFollowsAnUpdate() throws Exception {
+        FakeStatementService fakeService = new FakeStatementService(null, emptyQueryResult());
+        Connection connection = newConnection(fakeService);
+        PreparedStatement statement = new PreparedStatement(connection, "SELECT 1", fakeService);
+        // Simulate the exact regression scenario from PR #580: the statement previously produced
+        // a valid (>=0) update count (e.g. reused after an UPDATE), then executeQuery() must reset
+        // lastUpdateCount back to -1 rather than leaving the stale value in place.
+        statement.lastUpdateCount = 7;
+
+        statement.executeQuery();
+
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    @Test
+    void shouldReturnMinusOneWhenExecuteDelegatesToASelectStatement() throws Exception {
+        FakeStatementService fakeService = new FakeStatementService(null, emptyQueryResult());
+        Connection connection = newConnection(fakeService);
+        PreparedStatement statement = new PreparedStatement(connection, "SELECT 1", fakeService);
+
+        boolean isResultSet = statement.execute();
+
+        assertEquals(true, isResultSet);
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    @Test
+    void shouldReturnAffectedRowsWhenExecuteDelegatesToAnUpdateStatement() throws Exception {
+        FakeStatementService fakeService = new FakeStatementService(updateResult(3), null);
+        Connection connection = newConnection(fakeService);
+        PreparedStatement statement = new PreparedStatement(connection, "UPDATE t SET x = ?", fakeService);
+
+        boolean isResultSet = statement.execute();
+
+        assertEquals(false, isResultSet);
+        assertEquals(3, statement.getUpdateCount());
+    }
+
+    private static Connection newConnection(FakeStatementService fakeService) {
+        return new Connection(SESSION, fakeService, DbName.H2);
+    }
+
+    private static OpResult updateResult(int affectedRows) {
+        return OpResult.newBuilder()
+                .setSession(SESSION)
+                .setType(ResultType.INTEGER)
+                .setIntValue(affectedRows)
+                .build();
+    }
+
+    private static java.util.Iterator<OpResult> emptyQueryResult() {
+        OpResult result = OpResult.newBuilder()
+                .setSession(SESSION)
+                .setType(ResultType.RESULT_SET_DATA)
+                .setQueryResult(OpQueryResultProto.newBuilder().build())
+                .build();
+        return Collections.singletonList(result).iterator();
+    }
+}

--- a/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/StatementLastUpdateCountTest.java
+++ b/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/StatementLastUpdateCountTest.java
@@ -1,0 +1,120 @@
+package org.openjproxy.jdbc;
+
+import com.openjproxy.grpc.DbName;
+import com.openjproxy.grpc.OpQueryResultProto;
+import com.openjproxy.grpc.OpResult;
+import com.openjproxy.grpc.ResultType;
+import com.openjproxy.grpc.SessionInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for the {@code lastUpdateCount} JDBC contract on {@link Statement}.
+ *
+ * <p>Per the JDBC spec, {@link java.sql.Statement#getUpdateCount()} must return {@code -1}
+ * when the last executed statement produced a {@link java.sql.ResultSet} (or no statement has
+ * been executed yet), and the actual affected-row count otherwise. Returning {@code 0} instead
+ * of {@code -1} after a query makes clients that check {@code getUpdateCount() == -1} to detect
+ * "no more results" (e.g. DataGrip) believe an update result is still pending, causing them to
+ * hang indefinitely. See PR #580.</p>
+ */
+class StatementLastUpdateCountTest {
+
+    // SessionInfo with an empty connHash so Connection#getThrottleManager() returns null and
+    // client-side throttling is bypassed entirely for these unit tests.
+    private static final SessionInfo SESSION = SessionInfo.newBuilder().setConnHash("").build();
+
+    @Test
+    void shouldReturnMinusOneByDefaultBeforeAnyStatementIsExecuted() throws Exception {
+        Statement statement = new Statement(newConnection(new FakeStatementService()), new FakeStatementService());
+
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    @Test
+    void shouldReturnMinusOneAfterExecuteQuery() throws Exception {
+        FakeStatementService fakeService = new FakeStatementService(null, emptyQueryResult());
+        Connection connection = newConnection(fakeService);
+        Statement statement = new Statement(connection, fakeService);
+
+        statement.executeQuery("SELECT 1");
+
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    @Test
+    void shouldReturnAffectedRowsFromExecuteUpdate() throws Exception {
+        // executeUpdate(sql) returns the affected-row count directly; it does not touch
+        // lastUpdateCount (only execute(sql)/executeQuery(sql) do), so getUpdateCount() is
+        // intentionally not asserted here.
+        FakeStatementService fakeService = new FakeStatementService(updateResult(5), null);
+        Connection connection = newConnection(fakeService);
+        Statement statement = new Statement(connection, fakeService);
+
+        int affectedRows = statement.executeUpdate("UPDATE t SET x = 1");
+
+        assertEquals(5, affectedRows);
+    }
+
+    @Test
+    void shouldResetToMinusOneWhenExecuteQueryFollowsAnUpdate() throws Exception {
+        FakeStatementService fakeService = new FakeStatementService(updateResult(7), emptyQueryResult());
+        Connection connection = newConnection(fakeService);
+        Statement statement = new Statement(connection, fakeService);
+
+        statement.execute("UPDATE t SET x = 1");
+        assertEquals(7, statement.getUpdateCount());
+
+        statement.executeQuery("SELECT 1");
+
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    @Test
+    void shouldReturnMinusOneWhenExecuteDelegatesToASelectStatement() throws Exception {
+        FakeStatementService fakeService = new FakeStatementService(null, emptyQueryResult());
+        Connection connection = newConnection(fakeService);
+        Statement statement = new Statement(connection, fakeService);
+
+        boolean isResultSet = statement.execute("SELECT 1");
+
+        assertEquals(true, isResultSet);
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    @Test
+    void shouldReturnAffectedRowsWhenExecuteDelegatesToAnUpdateStatement() throws Exception {
+        FakeStatementService fakeService = new FakeStatementService(updateResult(3), null);
+        Connection connection = newConnection(fakeService);
+        Statement statement = new Statement(connection, fakeService);
+
+        boolean isResultSet = statement.execute("UPDATE t SET x = 1");
+
+        assertEquals(false, isResultSet);
+        assertEquals(3, statement.getUpdateCount());
+    }
+
+    private static Connection newConnection(FakeStatementService fakeService) {
+        return new Connection(SESSION, fakeService, DbName.H2);
+    }
+
+    private static OpResult updateResult(int affectedRows) {
+        return OpResult.newBuilder()
+                .setSession(SESSION)
+                .setType(ResultType.INTEGER)
+                .setIntValue(affectedRows)
+                .build();
+    }
+
+    private static java.util.Iterator<OpResult> emptyQueryResult() {
+        OpResult result = OpResult.newBuilder()
+                .setSession(SESSION)
+                .setType(ResultType.RESULT_SET_DATA)
+                .setQueryResult(OpQueryResultProto.newBuilder().build())
+                .build();
+        return Collections.singletonList(result).iterator();
+    }
+}


### PR DESCRIPTION
The Statement.lastUpdateCount field used Java's implicit default value for int (0), and was only explicitly set to -1 inside execute(String), never inside executeQuery(String)/executeQuery() - which are the methods DataGrip actually uses for SELECT queries.

Per the JDBC spec, getUpdateCount() returning 0 means 'the last statement affected 0 rows' (a valid update), while -1 means 'there is no update count' (the last statement was a query, or no statement was executed). DataGrip's UniversalResultsProducer uses getUpdateCount()==-1 to detect the end of result processing; since the driver incorrectly returned 0, DataGrip believed there was a pending update after getMoreResults()==false, and the UI spinner kept spinning indefinitely waiting for a result that would never arrive.

Fixes the field's default to -1 and adds the explicit assignment in Statement.executeQuery(String) and PreparedStatement.executeQuery().