### PR TITLE
fix: implement getFetchDirection/getFetchSize/setFetchSize locally without forcing proxy mode

### DIFF
--- a/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/ResultSet.java
+++ b/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/ResultSet.java
@@ -63,6 +63,19 @@ public class ResultSet extends RemoteProxyResultSet {
 
     private Object lastValueRead;
 
+    // Local cache for setFetchDirection()/getFetchDirection() when not in proxy mode.
+    // FETCH_FORWARD is the only direction compatible with this ResultSet's forward-only,
+    // block-streaming model (see getType()), so it must not force proxy mode: doing so would
+    // turn every subsequent next()/getXxx() call into an individual round trip to the server,
+    // even though FETCH_FORWARD is the default hint set by virtually every JDBC client/tool.
+    private int fetchDirectionHint = java.sql.ResultSet.FETCH_FORWARD;
+
+    // Local cache for setFetchSize()/getFetchSize() when not in proxy mode. Per the JDBC spec,
+    // fetch size is only a hint that a driver is free to ignore, so it must not throw for a
+    // well-formed value even though this streaming block-based ResultSet does not actually vary
+    // its block size based on it.
+    private int fetchSizeHint;
+
     public ResultSet(Iterator<OpResult> itOpResult, StatementService statementService, java.sql.Statement statement) throws SQLException {
         this.itResults = itOpResult;
         this.inProxyMode = false;
@@ -867,23 +880,42 @@ public class ResultSet extends RemoteProxyResultSet {
     @Override
     public void setFetchDirection(int direction) throws SQLException {
         log.debug("setFetchDirection: {}", direction);
-        super.setFetchDirection(direction);
-        this.inProxyMode = true;
+        if (this.inProxyMode) {
+            super.setFetchDirection(direction);
+            return;
+        }
+        if (direction != java.sql.ResultSet.FETCH_FORWARD) {
+            // This ResultSet only implements forward, block-streaming iteration; any other
+            // direction is delegated to the remote proxy so JDBC scrollable semantics stay correct.
+            super.setFetchDirection(direction);
+            this.inProxyMode = true;
+            return;
+        }
+        this.fetchDirectionHint = direction;
     }
 
     @Override
     public int getFetchDirection() throws SQLException {
         log.debug("getFetchDirection called");
-        return super.getFetchDirection();
+        if (this.inProxyMode) {
+            return super.getFetchDirection();
+        }
+        return this.fetchDirectionHint;
     }
 
     @Override
     public void setFetchSize(int rows) throws SQLException {
         log.debug("setFetchSize: {}", rows);
+        if (rows < 0) {
+            throw new SQLException("Fetch size cannot be negative: " + rows);
+        }
         if (this.inProxyMode) {
             super.setFetchSize(rows);
+            return;
         }
-        throw new RuntimeException("Not implemented");
+        // Fetch size is only a hint (JDBC spec); this ResultSet streams fixed-size blocks
+        // from the server, so the hint is stored but does not change the streaming behavior.
+        this.fetchSizeHint = rows;
     }
 
     @Override
@@ -892,7 +924,7 @@ public class ResultSet extends RemoteProxyResultSet {
         if (this.inProxyMode) {
             return super.getFetchSize();
         }
-        throw new RuntimeException("Not implemented");
+        return this.fetchSizeHint;
     }
 
     @Override

--- a/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/FakeStatementService.java
+++ b/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/FakeStatementService.java
@@ -7,10 +7,12 @@ import com.openjproxy.grpc.LobDataBlock;
 import com.openjproxy.grpc.LobReference;
 import com.openjproxy.grpc.OpResult;
 import com.openjproxy.grpc.SessionInfo;
+import org.openjproxy.grpc.ProtoConverter;
 import org.openjproxy.grpc.client.StatementService;
 import org.openjproxy.grpc.dto.Parameter;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -18,14 +20,17 @@ import java.util.Map;
 
 /**
  * Minimal {@link StatementService} test double used by unit tests that need to exercise
- * {@link Statement} / {@link PreparedStatement} behaviour without a real gRPC server.
- * Every method not overridden by the caller throws {@link UnsupportedOperationException}
+ * {@link Statement} / {@link PreparedStatement} / {@link ResultSet} behaviour without a real
+ * gRPC server. Every method not overridden by the caller throws {@link UnsupportedOperationException}
  * so accidental usage of unstubbed behaviour fails fast.
  */
 class FakeStatementService implements StatementService {
 
     private final OpResult executeUpdateResult;
     private final Iterator<OpResult> executeQueryResult;
+    private final List<CallResourceRequest> callResourceInvocations = new ArrayList<>();
+    private Object callResourceReturnValue;
+    private SessionInfo callResourceReturnSession;
 
     FakeStatementService() {
         this(null, Collections.emptyIterator());
@@ -34,6 +39,26 @@ class FakeStatementService implements StatementService {
     FakeStatementService(OpResult executeUpdateResult, Iterator<OpResult> executeQueryResult) {
         this.executeUpdateResult = executeUpdateResult;
         this.executeQueryResult = executeQueryResult;
+    }
+
+    /**
+     * Configures the value returned as the single value of the next {@link #callResource} response(s).
+     * Pass {@code null} for a void response (no returned value).
+     */
+    void setCallResourceReturnValue(Object value) {
+        this.callResourceReturnValue = value;
+    }
+
+    /**
+     * Configures the {@link SessionInfo} echoed back by {@link #callResource}. Defaults to the request's
+     * own session when not explicitly configured.
+     */
+    void setCallResourceReturnSession(SessionInfo session) {
+        this.callResourceReturnSession = session;
+    }
+
+    List<CallResourceRequest> getCallResourceInvocations() {
+        return this.callResourceInvocations;
     }
 
     @Override
@@ -102,7 +127,14 @@ class FakeStatementService implements StatementService {
 
     @Override
     public CallResourceResponse callResource(CallResourceRequest request) throws SQLException {
-        throw new UnsupportedOperationException();
+        this.callResourceInvocations.add(request);
+        CallResourceResponse.Builder response = CallResourceResponse.newBuilder()
+                .setSession(this.callResourceReturnSession != null ? this.callResourceReturnSession : request.getSession())
+                .setResourceUUID(request.getResourceUUID());
+        if (this.callResourceReturnValue != null) {
+            response.addValues(ProtoConverter.toParameterValue(this.callResourceReturnValue));
+        }
+        return response.build();
     }
 
     @Override

--- a/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/ResultSetFetchDirectionSizeTest.java
+++ b/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/ResultSetFetchDirectionSizeTest.java
@@ -1,0 +1,148 @@
+package org.openjproxy.jdbc;
+
+import com.openjproxy.grpc.CallResourceRequest;
+import com.openjproxy.grpc.CallType;
+import com.openjproxy.grpc.DbName;
+import com.openjproxy.grpc.OpQueryResultProto;
+import com.openjproxy.grpc.OpResult;
+import com.openjproxy.grpc.ResultType;
+import com.openjproxy.grpc.SessionInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ResultSet#getFetchDirection()}, {@link ResultSet#setFetchDirection(int)},
+ * {@link ResultSet#getFetchSize()} and {@link ResultSet#setFetchSize(int)}.
+ * <p>
+ * These JDBC hints must be handled locally (without forcing the ResultSet into proxy mode) as long
+ * as the direction stays {@code FETCH_FORWARD}, since that is the only direction compatible with
+ * this ResultSet's forward-only, block-streaming model. Any other direction (or a ResultSet already
+ * in proxy mode) must delegate to the remote proxy.
+ */
+class ResultSetFetchDirectionSizeTest {
+
+    private static final SessionInfo SESSION = SessionInfo.newBuilder().setConnHash("test-conn-hash").build();
+
+    private FakeStatementService fakeStatementService;
+    private Connection connection;
+    private Statement statement;
+
+    @BeforeEach
+    void setUp() {
+        this.fakeStatementService = new FakeStatementService();
+        this.connection = new Connection(SESSION, this.fakeStatementService, DbName.H2);
+        this.statement = new Statement(this.connection, this.fakeStatementService);
+    }
+
+    private ResultSet newResultSet() throws SQLException {
+        OpResult singleEmptyBlock = OpResult.newBuilder()
+                .setSession(SESSION)
+                .setType(ResultType.RESULT_SET_DATA)
+                .setQueryResult(OpQueryResultProto.newBuilder().setResultSetUUID("rs-uuid").build())
+                .build();
+        Iterator<OpResult> it = Collections.singletonList(singleEmptyBlock).iterator();
+        ResultSet resultSet = new ResultSet(it, this.fakeStatementService, this.statement);
+        resultSet.setConnection(this.connection);
+        return resultSet;
+    }
+
+    @Test
+    void shouldReturnFetchForwardByDefaultWithoutProxyCall() throws SQLException {
+        ResultSet resultSet = newResultSet();
+
+        assertEquals(java.sql.ResultSet.FETCH_FORWARD, resultSet.getFetchDirection());
+        assertTrue(this.fakeStatementService.getCallResourceInvocations().isEmpty());
+    }
+
+    @Test
+    void shouldStoreFetchForwardHintLocallyWithoutForcingProxyMode() throws SQLException {
+        ResultSet resultSet = newResultSet();
+
+        resultSet.setFetchDirection(java.sql.ResultSet.FETCH_FORWARD);
+
+        assertEquals(java.sql.ResultSet.FETCH_FORWARD, resultSet.getFetchDirection());
+        assertTrue(this.fakeStatementService.getCallResourceInvocations().isEmpty());
+    }
+
+    @Test
+    void shouldDelegateSetFetchDirectionToProxyForNonForwardDirection() throws SQLException {
+        ResultSet resultSet = newResultSet();
+
+        resultSet.setFetchDirection(java.sql.ResultSet.FETCH_REVERSE);
+
+        List<CallResourceRequest> invocations = this.fakeStatementService.getCallResourceInvocations();
+        assertEquals(1, invocations.size());
+        assertEquals(CallType.CALL_SET, invocations.get(0).getTarget().getCallType());
+        assertEquals("FetchDirection", invocations.get(0).getTarget().getResourceName());
+    }
+
+    @Test
+    void shouldDelegateGetFetchDirectionToProxyAfterNonForwardDirectionForcedProxyMode() throws SQLException {
+        ResultSet resultSet = newResultSet();
+        resultSet.setFetchDirection(java.sql.ResultSet.FETCH_REVERSE);
+        this.fakeStatementService.setCallResourceReturnValue(java.sql.ResultSet.FETCH_REVERSE);
+
+        int direction = resultSet.getFetchDirection();
+
+        assertEquals(java.sql.ResultSet.FETCH_REVERSE, direction);
+        List<CallResourceRequest> invocations = this.fakeStatementService.getCallResourceInvocations();
+        assertEquals(2, invocations.size());
+        assertEquals(CallType.CALL_GET, invocations.get(1).getTarget().getCallType());
+        assertEquals("FetchDirection", invocations.get(1).getTarget().getResourceName());
+    }
+
+    @Test
+    void shouldReturnZeroFetchSizeByDefaultWithoutProxyCall() throws SQLException {
+        ResultSet resultSet = newResultSet();
+
+        assertEquals(0, resultSet.getFetchSize());
+        assertTrue(this.fakeStatementService.getCallResourceInvocations().isEmpty());
+    }
+
+    @Test
+    void shouldStoreFetchSizeHintLocallyWithoutProxyCall() throws SQLException {
+        ResultSet resultSet = newResultSet();
+
+        resultSet.setFetchSize(25);
+
+        assertEquals(25, resultSet.getFetchSize());
+        assertTrue(this.fakeStatementService.getCallResourceInvocations().isEmpty());
+    }
+
+    @Test
+    void shouldThrowSQLExceptionForNegativeFetchSize() throws SQLException {
+        ResultSet resultSet = newResultSet();
+
+        assertThrows(SQLException.class, () -> resultSet.setFetchSize(-1));
+        assertTrue(this.fakeStatementService.getCallResourceInvocations().isEmpty());
+    }
+
+    @Test
+    void shouldDelegateFetchSizeToProxyWhenAlreadyInProxyMode() throws SQLException {
+        ResultSet resultSet = newResultSet();
+        // Force proxy mode via a non-forward fetch direction.
+        resultSet.setFetchDirection(java.sql.ResultSet.FETCH_REVERSE);
+
+        resultSet.setFetchSize(50);
+        this.fakeStatementService.setCallResourceReturnValue(50);
+        int fetchSize = resultSet.getFetchSize();
+
+        assertEquals(50, fetchSize);
+        List<CallResourceRequest> invocations = this.fakeStatementService.getCallResourceInvocations();
+        // [0] = setFetchDirection, [1] = setFetchSize, [2] = getFetchSize
+        assertEquals(3, invocations.size());
+        assertEquals("FetchSize", invocations.get(1).getTarget().getResourceName());
+        assertEquals(CallType.CALL_SET, invocations.get(1).getTarget().getCallType());
+        assertEquals("FetchSize", invocations.get(2).getTarget().getResourceName());
+        assertEquals(CallType.CALL_GET, invocations.get(2).getTarget().getCallType());
+    }
+}


### PR DESCRIPTION
Previously, setFetchDirection() always forced inProxyMode=true, and getFetchSize()/setFetchSize() threw RuntimeException("Not implemented") outside of proxy mode. This caused any caller that set these JDBC hints (common in tools like DataGrip) to force every subsequent next()/getXxx() call into an individual server round-trip, or to receive an unexpected exception.

FETCH_FORWARD (the only direction compatible with this ResultSet's forward-only, block-streaming model) and the fetch size are now stored locally as hints, without forcing proxy mode. Any other fetch direction still delegates to the remote proxy to preserve scrollable ResultSet semantics.