### PR TITLE
refactor: extract SQL classification (query vs update) into SqlStatementClassifier

### DIFF
--- a/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/PreparedStatement.java
+++ b/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/PreparedStatement.java
@@ -410,8 +410,7 @@ public class PreparedStatement extends Statement implements java.sql.PreparedSta
     public boolean execute() throws SQLException {
         log.debug("execute called");
         this.checkClosed();
-        String trimmedSql = this.sql.trim().toUpperCase();
-        if (trimmedSql.startsWith("SELECT")) {
+        if (SqlStatementClassifier.looksLikeQuery(this.sql)) {
             // Delegate to executeQuery
             ResultSet resultSet = this.executeQuery();
             // Store the ResultSet for later retrieval if needed

--- a/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/SqlStatementClassifier.java
+++ b/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/SqlStatementClassifier.java
@@ -1,0 +1,59 @@
+package org.openjproxy.jdbc;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Best-effort static classifier that decides, without executing the SQL, whether a statement
+ * is expected to return a {@link java.sql.ResultSet} (e.g. SELECT-style queries) or an update
+ * count (INSERT/UPDATE/DELETE/DDL/stored procedure calls).
+ *
+ * <p>OJP's wire protocol exposes two distinct RPCs for query and update execution
+ * ({@code executeQuery} streams result rows, {@code executeUpdate} returns a row count). The
+ * generic {@link java.sql.Statement#execute(String)} / {@link java.sql.PreparedStatement#execute()}
+ * contract does not tell the caller in advance which one applies, so this classifier inspects the
+ * SQL text once, before any network round trip, to route the call to the correct RPC.
+ *
+ * <p>This is a heuristic, not a SQL parser: it cannot detect every case (e.g. a stored procedure
+ * that conditionally returns rows depending on its arguments). Statements it cannot recognize as
+ * query-shaped default to "update", matching the historical OJP behaviour. Tools that rely heavily
+ * on {@code DatabaseMetaData} (e.g. SQL IDEs) frequently issue metadata calls that do not start
+ * with {@code SELECT} (CTEs via {@code WITH}, catalog stored procedures such as
+ * {@code sp_columns}/{@code sp_tables} on SQL Server, {@code CALL}/{@code EXEC} statements, etc.),
+ * which is why the prefix list below is broader than a plain {@code SELECT} check.
+ */
+final class SqlStatementClassifier {
+
+    private static final Pattern LEADING_COMMENTS = Pattern.compile(
+            "\\A(\\s*(--[^\\n]*\\n|/\\*.*?\\*/))*\\s*", Pattern.DOTALL);
+
+    private static final String[] RESULT_SET_PREFIXES = {
+        "SELECT", "WITH", "EXEC ", "EXEC(", "EXECUTE ", "EXECUTE(", "CALL ", "CALL(",
+        "SHOW ", "DESCRIBE ", "DESC ", "EXPLAIN ", "VALUES ", "VALUES(", "PRAGMA ", "SP_",
+    };
+
+    private SqlStatementClassifier() {
+        // Utility class, no instances.
+    }
+
+    /**
+     * Returns {@code true} when the given SQL text is likely to produce a {@link java.sql.ResultSet}
+     * rather than an update count.
+     *
+     * @param sql the raw SQL text as supplied by the caller
+     * @return {@code true} if the statement should be routed to {@code executeQuery}
+     */
+    static boolean looksLikeQuery(String sql) {
+        if (sql == null) {
+            return false;
+        }
+        String withoutLeadingComments = LEADING_COMMENTS.matcher(sql).replaceFirst("");
+        String upperSql = withoutLeadingComments.trim().toUpperCase(Locale.ROOT);
+        for (String prefix : RESULT_SET_PREFIXES) {
+            if (upperSql.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/SqlStatementClassifier.java
+++ b/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/SqlStatementClassifier.java
@@ -1,7 +1,6 @@
 package org.openjproxy.jdbc;
 
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 /**
  * Best-effort static classifier that decides, without executing the SQL, whether a statement
@@ -24,9 +23,6 @@ import java.util.regex.Pattern;
  */
 final class SqlStatementClassifier {
 
-    private static final Pattern LEADING_COMMENTS = Pattern.compile(
-            "\\A(\\s*(--[^\\n]*\\n|/\\*.*?\\*/))*\\s*", Pattern.DOTALL);
-
     private static final String[] RESULT_SET_PREFIXES = {
         "SELECT", "WITH", "EXEC ", "EXEC(", "EXECUTE ", "EXECUTE(", "CALL ", "CALL(",
         "SHOW ", "DESCRIBE ", "DESC ", "EXPLAIN ", "VALUES ", "VALUES(", "PRAGMA ", "SP_",
@@ -47,13 +43,44 @@ final class SqlStatementClassifier {
         if (sql == null) {
             return false;
         }
-        String withoutLeadingComments = LEADING_COMMENTS.matcher(sql).replaceFirst("");
-        String upperSql = withoutLeadingComments.trim().toUpperCase(Locale.ROOT);
+        String withoutLeadingComments = skipLeadingWhitespaceAndComments(sql);
+        String upperSql = withoutLeadingComments.toUpperCase(Locale.ROOT);
         for (String prefix : RESULT_SET_PREFIXES) {
             if (upperSql.startsWith(prefix)) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * Skips leading whitespace and SQL comments ({@code --} line comments and {@code /* *}{@code /}
+     * block comments) from the given text, using a manual scan instead of a repeated-group regex
+     * to avoid catastrophic backtracking on large inputs.
+     *
+     * @param sql the raw SQL text
+     * @return the text with leading whitespace/comments removed
+     */
+    private static String skipLeadingWhitespaceAndComments(String sql) {
+        int length = sql.length();
+        int index = 0;
+        boolean advanced = true;
+        while (advanced) {
+            advanced = false;
+            while (index < length && Character.isWhitespace(sql.charAt(index))) {
+                index++;
+                advanced = true;
+            }
+            if (index + 1 < length && sql.charAt(index) == '-' && sql.charAt(index + 1) == '-') {
+                int newLine = sql.indexOf('\n', index + 2);
+                index = newLine < 0 ? length : newLine + 1;
+                advanced = true;
+            } else if (index + 1 < length && sql.charAt(index) == '/' && sql.charAt(index + 1) == '*') {
+                int endComment = sql.indexOf("*/", index + 2);
+                index = endComment < 0 ? length : endComment + 2;
+                advanced = true;
+            }
+        }
+        return sql.substring(index);
     }
 }

--- a/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/Statement.java
+++ b/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/Statement.java
@@ -263,8 +263,7 @@ public class Statement implements java.sql.Statement {
     public boolean execute(String sql) throws SQLException {
         log.debug("execute: {}", sql);
         checkClosed();
-        String trimmedSql = sql.trim().toUpperCase();
-        if (trimmedSql.startsWith("SELECT")) {
+        if (SqlStatementClassifier.looksLikeQuery(sql)) {
             // Delegate to executeQuery
             ResultSet resultSet = this.executeQuery(sql);
             // Store the ResultSet for later retrieval if needed

--- a/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/H2PreparedStatementExtensiveTests.java
+++ b/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/H2PreparedStatementExtensiveTests.java
@@ -222,6 +222,46 @@ public class H2PreparedStatementExtensiveTests {
         }
     }
 
+    /**
+     * Regression test for {@code SqlStatementClassifier}: a CTE (WITH ...) must be routed to
+     * executeQuery by execute(), not just a plain SELECT prefix.
+     */
+    @ParameterizedTest
+    @CsvFileSource(resources = "/h2_connection.csv")
+    void testExecuteWithCommonTableExpression(String driverClass, String url, String user, String password) throws Exception {
+        this.setUp(driverClass, url, user, password);
+        Statement stmt = connection.createStatement();
+        stmt.execute("INSERT INTO h2_prepared_stmt_test (id, name, age) VALUES (20, 'Cte', 40)");
+        stmt.close();
+
+        ps = connection.prepareStatement(
+                "WITH cte AS (SELECT * FROM h2_prepared_stmt_test WHERE id = 20) SELECT * FROM cte");
+        boolean isResultSet = ps.execute();
+        assertTrue(isResultSet);
+        ResultSet rs = ps.getResultSet();
+        assertNotNull(rs);
+        assertTrue(rs.next());
+        rs.close();
+        assertEquals(-1, ps.getUpdateCount());
+    }
+
+    /**
+     * Regression test for {@code SqlStatementClassifier}: a leading SQL comment before SELECT
+     * must not prevent the statement from being recognized as query-shaped.
+     */
+    @ParameterizedTest
+    @CsvFileSource(resources = "/h2_connection.csv")
+    void testExecuteWithLeadingCommentBeforeSelect(String driverClass, String url, String user, String password) throws Exception {
+        this.setUp(driverClass, url, user, password);
+        ps = connection.prepareStatement("-- a leading comment\nSELECT * FROM h2_prepared_stmt_test");
+        boolean isResultSet = ps.execute();
+        assertTrue(isResultSet);
+        ResultSet rs = ps.getResultSet();
+        assertNotNull(rs);
+        rs.close();
+        assertEquals(-1, ps.getUpdateCount());
+    }
+
     @ParameterizedTest
     @CsvFileSource(resources = "/h2_connection.csv")
     void testMetaDataAndWarnings(String driverClass, String url, String user, String password) throws Exception {

--- a/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/H2StatementExtensiveTests.java
+++ b/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/H2StatementExtensiveTests.java
@@ -193,6 +193,59 @@ public class H2StatementExtensiveTests {
         assertEquals(1, statement.getUpdateCount());
     }
 
+    /**
+     * Regression test for {@code SqlStatementClassifier}: a plain {@code startsWith("SELECT")}
+     * check missed a CTE (WITH ...), which is common in tools like SQL IDEs. execute() must
+     * route it to executeQuery so a ResultSet, not an update count, is produced.
+     */
+    @ParameterizedTest
+    @CsvFileSource(resources = "/h2_connection.csv")
+    void testExecuteWithCommonTableExpression(String driverClass, String url, String user, String password) throws Exception {
+        this.setUp(driverClass, url, user, password);
+        boolean isResultSet = statement.execute(
+                "WITH cte AS (SELECT * FROM h2_statement_test) SELECT * FROM cte");
+        assertTrue(isResultSet);
+        ResultSet rs = statement.getResultSet();
+        assertNotNull(rs);
+        assertTrue(rs.next());
+        rs.close();
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    /**
+     * Regression test for {@code SqlStatementClassifier}: a leading SQL comment before SELECT
+     * must not prevent the statement from being recognized as query-shaped.
+     */
+    @ParameterizedTest
+    @CsvFileSource(resources = "/h2_connection.csv")
+    void testExecuteWithLeadingCommentBeforeSelect(String driverClass, String url, String user, String password) throws Exception {
+        this.setUp(driverClass, url, user, password);
+        boolean isResultSet = statement.execute(
+                "-- a leading comment\nSELECT * FROM h2_statement_test");
+        assertTrue(isResultSet);
+        ResultSet rs = statement.getResultSet();
+        assertNotNull(rs);
+        rs.close();
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
+    /**
+     * Regression test for {@code SqlStatementClassifier}: H2's {@code VALUES} table constructor
+     * is query-shaped even though it does not start with SELECT.
+     */
+    @ParameterizedTest
+    @CsvFileSource(resources = "/h2_connection.csv")
+    void testExecuteWithValuesStatement(String driverClass, String url, String user, String password) throws Exception {
+        this.setUp(driverClass, url, user, password);
+        boolean isResultSet = statement.execute("VALUES (1), (2), (3)");
+        assertTrue(isResultSet);
+        ResultSet rs = statement.getResultSet();
+        assertNotNull(rs);
+        assertTrue(rs.next());
+        rs.close();
+        assertEquals(-1, statement.getUpdateCount());
+    }
+
     @ParameterizedTest
     @CsvFileSource(resources = "/h2_connection.csv")
     void testGetMoreResults(String driverClass, String url, String user, String password) throws Exception {

--- a/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/SqlStatementClassifierTest.java
+++ b/ojp-jdbc-driver/src/test/java/org/openjproxy/jdbc/SqlStatementClassifierTest.java
@@ -1,0 +1,109 @@
+package org.openjproxy.jdbc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link SqlStatementClassifier#looksLikeQuery(String)}.
+ */
+class SqlStatementClassifierTest {
+
+    @ParameterizedTest
+    @NullSource
+    void shouldReturnFalseForNullSql(String sql) {
+        assertFalse(SqlStatementClassifier.looksLikeQuery(sql));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "SELECT * FROM t",
+        "select * from t",
+        "Select * From t",
+        "  SELECT * FROM t",
+        "\n\tSELECT * FROM t",
+    })
+    void shouldRecognizeSelectStatements(String sql) {
+        assertTrue(SqlStatementClassifier.looksLikeQuery(sql));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "WITH cte AS (SELECT 1) SELECT * FROM cte",
+        "with cte as (select 1) select * from cte",
+    })
+    void shouldRecognizeCommonTableExpressions(String sql) {
+        assertTrue(SqlStatementClassifier.looksLikeQuery(sql));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "EXEC sp_help",
+        "exec sp_help",
+        "EXEC(sp_help)",
+        "EXECUTE sp_help",
+        "EXECUTE(sp_help)",
+        "CALL my_proc()",
+        "call my_proc()",
+        "CALL(1)",
+        "SHOW TABLES",
+        "DESCRIBE t",
+        "DESC t",
+        "EXPLAIN SELECT * FROM t",
+        "VALUES (1, 2, 3)",
+        "VALUES(1)",
+        "PRAGMA table_info(t)",
+        "sp_columns t",
+        "SP_TABLES",
+    })
+    void shouldRecognizeOtherQueryShapedStatements(String sql) {
+        assertTrue(SqlStatementClassifier.looksLikeQuery(sql));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "INSERT INTO t VALUES (1)",
+        "UPDATE t SET x = 1",
+        "DELETE FROM t",
+        "CREATE TABLE t (id INT)",
+        "DROP TABLE t",
+        "ALTER TABLE t ADD COLUMN x INT",
+        "MERGE INTO t USING s ON t.id = s.id",
+        "TRUNCATE TABLE t",
+    })
+    void shouldNotRecognizeUpdateShapedStatements(String sql) {
+        assertFalse(SqlStatementClassifier.looksLikeQuery(sql));
+    }
+
+    @Test
+    void shouldSkipLeadingLineCommentBeforeSelect() {
+        assertTrue(SqlStatementClassifier.looksLikeQuery("-- a leading line comment\nSELECT * FROM t"));
+    }
+
+    @Test
+    void shouldSkipLeadingBlockCommentBeforeSelect() {
+        assertTrue(SqlStatementClassifier.looksLikeQuery("/* a leading block comment */ SELECT * FROM t"));
+    }
+
+    @Test
+    void shouldSkipMultipleLeadingCommentsAndWhitespaceBeforeSelect() {
+        assertTrue(SqlStatementClassifier.looksLikeQuery(
+                "/* multi\nline block comment */\n-- then a line comment\nSELECT * FROM t"));
+    }
+
+    @Test
+    void shouldNotRecognizeStatementThatIsOnlyALineComment() {
+        // Nothing follows the comment (it consumes the rest of the input), so no prefix matches.
+        assertFalse(SqlStatementClassifier.looksLikeQuery("  \n  -- comment only, nothing after (until EOF)"));
+    }
+
+    @Test
+    void shouldNotRecognizeStatementWithUnterminatedBlockComment() {
+        // The unterminated block comment consumes the rest of the input, including the SELECT keyword.
+        assertFalse(SqlStatementClassifier.looksLikeQuery("/* unterminated block comment SELECT * FROM t"));
+    }
+}


### PR DESCRIPTION
Statement.execute(String) and PreparedStatement.execute() decided whether a statement should be routed to executeQuery or executeUpdate using only trimmedSql.startsWith("SELECT"). This fails for several common cases used by SQL tools (SQL IDEs): CTEs via WITH, catalog stored procedures such as sp_columns/sp_tables on SQL Server, CALL/EXEC, SHOW/DESCRIBE/EXPLAIN, etc.

Extracts the logic into SqlStatementClassifier.looksLikeQuery(sql), a broader heuristic (still not a full SQL parser) that covers these additional prefixes, skips leading comments, and centralizes the decision in a single place reused by both Statement and PreparedStatement.