### PR TITLE
fix: fix SQLWarning serialization between server and JDBC driver

### DIFF
--- a/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/Connection.java
+++ b/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/Connection.java
@@ -315,7 +315,10 @@ public class Connection implements java.sql.Connection {
     public SQLWarning getWarnings() throws SQLException {
         log.debug("getWarnings called");
         checkValid();
-        return this.callProxy(CallType.CALL_GET, "Warnings", SQLWarning.class);
+        // The server serializes SQLWarning as a plain message string (see CallResourceAction),
+        // since arbitrary Throwable graphs cannot be transported as primitives/Map/List/Properties.
+        String message = this.callProxy(CallType.CALL_GET, "Warnings", String.class);
+        return message == null ? null : new SQLWarning(message);
     }
 
     @Override

--- a/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/Statement.java
+++ b/ojp-jdbc-driver/src/main/java/org/openjproxy/jdbc/Statement.java
@@ -236,7 +236,10 @@ public class Statement implements java.sql.Statement {
     public SQLWarning getWarnings() throws SQLException {
         log.debug("getWarnings called");
         checkClosed();
-        return this.callProxy(CallType.CALL_GET, "Warnings", SQLWarning.class);
+        // The server serializes SQLWarning as a plain message string (see CallResourceAction),
+        // since arbitrary Throwable graphs cannot be transported as primitives/Map/List/Properties.
+        String message = this.callProxy(CallType.CALL_GET, "Warnings", String.class);
+        return message == null ? null : new SQLWarning(message);
     }
 
     @Override

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/action/resource/CallResourceAction.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/action/resource/CallResourceAction.java
@@ -25,6 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.SQLWarning;
 import java.sql.Savepoint;
 import java.util.List;
 import java.util.Map;
@@ -211,6 +212,12 @@ public class CallResourceAction implements Action<CallResourceRequest, CallResou
                 String uuid = UUID.randomUUID().toString();
                 resultFirstLevel = uuid;
                 context.getSessionManager().registerAttr(responseBuilder.getSession(), uuid, sp);
+            }
+            if (resultFirstLevel instanceof SQLWarning warning) {
+                // SQLWarning (and its vendor-specific subclasses, e.g. SQLServerWarning) cannot be
+                // transported as-is since ProtoConverter only supports primitives/Map/List/Properties.
+                // Flatten it to its message text; the client reconstructs a plain SQLWarning from it.
+                resultFirstLevel = warning.getMessage();
             }
             if (request.getTarget().hasNextCall()) {
                 //Second level calls, for cases like getMetadata().isAutoIncrement(int column)


### PR DESCRIPTION
SQLWarning (and its vendor-specific subclasses, e.g. SQLServerWarning) cannot be transported as-is over OJP's gRPC protocol, which only supports primitives/Map/List/Properties via ProtoConverter. Calls to getWarnings() failed or returned incorrect data.

The server now extracts only the SQLWarning's text message before sending the response (CallResourceAction), and the client driver (Statement and Connection) rebuilds a plain SQLWarning from that message.